### PR TITLE
fix: resolve SQLite permissions error on Unraid volume mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
+RUN apk add --no-cache su-exec
 
 # Copy standalone output
 COPY --from=builder /app/public ./public
@@ -46,7 +47,9 @@ COPY --from=builder /app/src/lib/db/migrations ./src/lib/db/migrations
 # Create data directory for SQLite
 RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
 
-USER nextjs
+# Copy entrypoint script
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 3000
 
@@ -62,4 +65,5 @@ ENV DATABASE_PATH=/app/data/shelflife.db
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Fix ownership of the data directory.
+# When a host volume is mounted (e.g. on Unraid), it's typically owned by root,
+# which the nextjs user (uid 1001) can't write to.
+chown nextjs:nodejs /app/data
+
+exec su-exec nextjs "$@"


### PR DESCRIPTION
## Summary

- Adds `docker-entrypoint.sh` that fixes ownership of `/app/data` before starting the app
- Installs `su-exec` in the Alpine image for privilege dropping
- Entrypoint runs as root to `chown` the mounted volume, then drops to the `nextjs` user via `su-exec`
- Fixes `SQLITE_CANTOPEN` errors when Unraid mounts a host directory owned by root

## Root cause

The Dockerfile had `USER nextjs` which meant the app started as uid 1001. But Unraid volume mounts (`/mnt/user/appdata/shelflife:/app/data`) are owned by root, so the `nextjs` user couldn't create or write to the SQLite database file.

## Test plan

- [ ] Merge and wait for Docker image to build
- [ ] On Unraid: pull latest image and recreate container
- [ ] Verify the app starts without `SQLITE_CANTOPEN` errors
- [ ] Verify the SQLite database is created at `/app/data/shelflife.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)