### PR TITLE
fix: auto-run database migrations on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ COPY --from=builder /app/src/lib/db/migrations ./src/lib/db/migrations
 # Create data directory for SQLite
 RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
 
-# Copy entrypoint script
+# Copy migration script and entrypoint
+COPY migrate.js /app/migrate.js
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,4 +6,7 @@ set -e
 # which the nextjs user (uid 1001) can't write to.
 chown nextjs:nodejs /app/data
 
+# Run database migrations (creates tables if they don't exist)
+su-exec nextjs node /app/migrate.js
+
 exec su-exec nextjs "$@"

--- a/migrate.js
+++ b/migrate.js
@@ -1,0 +1,60 @@
+// Standalone migration script - runs in Docker entrypoint before the app starts.
+// Reads Drizzle-generated SQL migration files and executes them against SQLite.
+// Safe to run repeatedly: catches "already exists" errors gracefully.
+
+const Database = require("better-sqlite3");
+const fs = require("fs");
+const path = require("path");
+
+const dbPath = process.env.DATABASE_PATH || "/app/data/shelflife.db";
+const migrationsDir = path.join(__dirname, "src/lib/db/migrations");
+
+// Ensure data directory exists
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+const db = new Database(dbPath);
+db.pragma("journal_mode = WAL");
+db.pragma("foreign_keys = ON");
+
+if (!fs.existsSync(migrationsDir)) {
+  console.log("No migrations directory found, skipping");
+  db.close();
+  process.exit(0);
+}
+
+const files = fs
+  .readdirSync(migrationsDir)
+  .filter((f) => f.endsWith(".sql"))
+  .sort();
+
+let applied = 0;
+let skipped = 0;
+
+for (const file of files) {
+  const sql = fs.readFileSync(path.join(migrationsDir, file), "utf-8");
+  // Drizzle uses '--> statement-breakpoint' to separate SQL statements
+  const statements = sql.split("--> statement-breakpoint");
+
+  for (const stmt of statements) {
+    const trimmed = stmt.trim();
+    if (!trimmed) continue;
+
+    try {
+      db.exec(trimmed);
+      applied++;
+    } catch (e) {
+      if (e.message && e.message.includes("already exists")) {
+        skipped++;
+      } else {
+        console.error(`Migration failed (${file}):`, e.message);
+        db.close();
+        process.exit(1);
+      }
+    }
+  }
+}
+
+db.close();
+console.log(
+  `Migrations complete: ${applied} applied, ${skipped} already existed`
+);


### PR DESCRIPTION
Add a standalone migrate.js script that reads Drizzle-generated SQL migration files and executes them against SQLite on container startup. This creates the tables automatically on first run.

The script runs in the Docker entrypoint (as the nextjs user) before the Node.js server starts. It's safe to run repeatedly — "already exists" errors are caught and skipped gracefully.