### PR TITLE
fix: session cookie not persisting over plain HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Shelflife is read-only against your external services -- it never deletes anythi
 | `PLEX_CLIENT_ID`    | No       | Identifier for Plex auth (defaults to `shelflife`)                                     |
 | `ADMIN_PLEX_ID`     | No       | Force a specific Plex user as admin. If unset, the first user to sign in becomes admin |
 | `DATABASE_PATH`     | No       | Path to SQLite database (defaults to `/app/data/shelflife.db` in Docker)               |
+| `COOKIE_SECURE`     | No       | Set to `true` if behind HTTPS reverse proxy. Defaults to `false` for plain HTTP        |
 | `DEBUG`             | No       | Set to `true` for verbose debug logging (useful for troubleshooting)                   |
 
 ## Running with Docker Compose

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -27,7 +27,7 @@ export async function setSessionCookie(token: string) {
   const cookieStore = await cookies();
   cookieStore.set(SESSION_COOKIE, token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: process.env.COOKIE_SECURE === "true",
     sameSite: "lax",
     maxAge: SESSION_MAX_AGE,
     path: "/",


### PR DESCRIPTION
The session cookie was set with `secure: true` in production (NODE_ENV=production), but Unraid users access the app over plain HTTP on their LAN. Secure cookies are silently dropped by browsers on non-HTTPS connections.

Changed to opt-in via COOKIE_SECURE=true env var, defaulting to false. Users behind an HTTPS reverse proxy can enable it.