### PR TITLE
feat: toast notifications for sync results

### DIFF
--- a/src/components/admin/SyncStatus.tsx
+++ b/src/components/admin/SyncStatus.tsx
@@ -26,7 +26,7 @@ interface SyncResult {
   tautulli?: number;
 }
 
-function formatSyncResult(synced: SyncResult): string {
+export function formatSyncResult(synced: SyncResult): string {
   const parts: string[] = [];
   if (synced.overseerr != null) {
     parts.push(`${synced.overseerr} media item${synced.overseerr !== 1 ? "s" : ""}`);

--- a/src/components/admin/__tests__/SyncStatus.test.ts
+++ b/src/components/admin/__tests__/SyncStatus.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { formatSyncResult } from "../SyncStatus";
+
+describe("formatSyncResult", () => {
+  it("formats full sync with both overseerr and tautulli", () => {
+    expect(formatSyncResult({ overseerr: 771, tautulli: 49 })).toBe(
+      "Synced 771 media items and 49 watch records"
+    );
+  });
+
+  it("formats overseerr-only sync", () => {
+    expect(formatSyncResult({ overseerr: 100 })).toBe("Synced 100 media items");
+  });
+
+  it("formats tautulli-only sync", () => {
+    expect(formatSyncResult({ tautulli: 25 })).toBe("Synced 25 watch records");
+  });
+
+  it("handles singular media item", () => {
+    expect(formatSyncResult({ overseerr: 1 })).toBe("Synced 1 media item");
+  });
+
+  it("handles singular watch record", () => {
+    expect(formatSyncResult({ tautulli: 1 })).toBe("Synced 1 watch record");
+  });
+
+  it("handles zero counts", () => {
+    expect(formatSyncResult({ overseerr: 0, tautulli: 0 })).toBe(
+      "Synced 0 media items and 0 watch records"
+    );
+  });
+
+  it("returns fallback for empty result", () => {
+    expect(formatSyncResult({})).toBe("Sync complete");
+  });
+});

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -49,6 +49,7 @@ export function Toast({ message, type, onDismiss, duration = 5000 }: ToastProps)
             setVisible(false);
             setTimeout(onDismiss, 300);
           }}
+          aria-label="Close notification"
           className="ml-auto shrink-0 text-gray-500 hover:text-gray-300"
         >
           <svg


### PR DESCRIPTION
## Summary
- **Toast notifications**: Sync results now show as a polished toast notification (top-right, auto-dismisses after 5s) instead of inline text with raw JSON
- **Friendly messages**: "Synced 771 media items and 49 watch records" instead of `{"overseerr":771,"tautulli":49}`
- **Auto-refresh**: After sync completes, all admin page stats (Total Media, Users, Keep/Delete Votes), the users table, and deletion candidates automatically refresh via `router.refresh()`

## Test plan
- [x] All 153 existing tests pass
- [ ] Run a Full Sync and verify toast appears with friendly message
- [ ] Verify stats cards update automatically after sync
- [ ] Run Overseerr Only / Tautulli Only and verify single-source message
- [ ] Verify error toast on sync failure
- [ ] Verify toast auto-dismisses after 5 seconds and can be manually closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)