### PR TITLE
Fix migration failure on duplicate column

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -43,7 +43,11 @@ for (const file of files) {
       db.exec(trimmed);
       applied++;
     } catch (e) {
-      if (e.message && e.message.includes("already exists")) {
+      if (
+        e.message &&
+        (e.message.includes("already exists") ||
+          e.message.includes("duplicate column name"))
+      ) {
         skipped++;
       } else {
         console.error(`Migration failed (${file}):`, e.message);


### PR DESCRIPTION
## Summary
- Fix `migrate.js` to catch `"duplicate column name"` errors as safe-to-skip, matching the existing `"already exists"` handling
- SQLite `ALTER TABLE ADD` throws a different error message than `CREATE TABLE` when the object already exists, causing migrations to hard-fail on re-runs

## Test plan
- [ ] Deploy to Unraid with existing database that has `imdb_id` column — migration should complete without error
- [ ] Fresh deploy — migration should apply all statements normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)