### PR TITLE
Add universal sorting to all routes and handle removed items in commu…

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -1,6 +1,6 @@
 // Standalone migration script - runs in Docker entrypoint before the app starts.
 // Reads Drizzle-generated SQL migration files and executes them against SQLite.
-// Safe to run repeatedly: catches "already exists" errors gracefully.
+// Safe to run repeatedly: catches "already exists" and "duplicate column name" errors gracefully.
 
 const Database = require("better-sqlite3");
 const fs = require("fs");

--- a/src/components/community/CommunityCard.tsx
+++ b/src/components/community/CommunityCard.tsx
@@ -98,25 +98,33 @@ export function CommunityCard({ item, onVoteChange, onSelfVoteChange }: Communit
             </svg>
           </a>
         )}
-        <VoteTallyBar keepCount={item.tally.keepCount} removeCount={item.tally.removeCount} />
-        {item.isOwn ? (
-          <div className="space-y-1">
-            <p className="text-xs text-gray-500">Your nomination — change your vote:</p>
-            <VoteButton
-              mediaItemId={item.id}
-              currentVote={item.nominationType}
-              seasonCount={item.seasonCount}
-              mediaType={item.mediaType}
-              currentKeepSeasons={item.keepSeasons}
-              onVoteChange={(newVote) => onSelfVoteChange?.(item.id, newVote)}
-            />
+        {item.status === "removed" ? (
+          <div className="rounded bg-red-900/30 px-2 py-2 text-center text-sm font-medium text-red-400">
+            Removed from library
           </div>
         ) : (
-          <CommunityVoteButton
-            mediaItemId={item.id}
-            currentVote={item.currentUserVote}
-            onVoteChange={(vote, delta) => onVoteChange?.(item.id, vote, delta)}
-          />
+          <>
+            <VoteTallyBar keepCount={item.tally.keepCount} removeCount={item.tally.removeCount} />
+            {item.isOwn ? (
+              <div className="space-y-1">
+                <p className="text-xs text-gray-500">Your nomination — change your vote:</p>
+                <VoteButton
+                  mediaItemId={item.id}
+                  currentVote={item.nominationType}
+                  seasonCount={item.seasonCount}
+                  mediaType={item.mediaType}
+                  currentKeepSeasons={item.keepSeasons}
+                  onVoteChange={(newVote) => onSelfVoteChange?.(item.id, newVote)}
+                />
+              </div>
+            ) : (
+              <CommunityVoteButton
+                mediaItemId={item.id}
+                currentVote={item.currentUserVote}
+                onVoteChange={(vote, delta) => onVoteChange?.(item.id, vote, delta)}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/media/MediaGrid.tsx
+++ b/src/components/media/MediaGrid.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { MediaCard } from "./MediaCard";
 import { Pagination } from "../ui/Pagination";
 import { MediaCardSkeleton } from "../ui/MediaCardSkeleton";
-import { VOTE_LABELS } from "@/lib/constants";
+import { VOTE_LABELS, SORT_LABELS } from "@/lib/constants";
 import type { MediaItemWithVote, VoteValue } from "@/types";
 
 interface MediaGridProps {
@@ -25,6 +25,7 @@ export function MediaGrid({ initialItems, statsFilter, onVoteChange }: MediaGrid
     type: "all",
     status: "all",
     vote: "all",
+    sort: "title_asc",
   });
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -53,6 +54,7 @@ export function MediaGrid({ initialItems, statsFilter, onVoteChange }: MediaGrid
         type: filters.type,
         status: filters.status,
         vote: filters.vote,
+        sort: filters.sort,
       });
 
       if (debouncedSearch) {
@@ -127,6 +129,7 @@ export function MediaGrid({ initialItems, statsFilter, onVoteChange }: MediaGrid
           <option value="pending">Pending</option>
           <option value="processing">Processing</option>
           <option value="partial">Partial</option>
+          <option value="removed">Removed</option>
         </select>
         {!statsFilter && (
           <select
@@ -144,6 +147,20 @@ export function MediaGrid({ initialItems, statsFilter, onVoteChange }: MediaGrid
             <option value="none">Not Voted</option>
           </select>
         )}
+        <select
+          value={filters.sort}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, sort: e.target.value }));
+            setPage(1);
+          }}
+          className="rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-200"
+        >
+          {Object.entries(SORT_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
         {statsFilter && (
           <span className="flex items-center text-sm text-[#e5a00d]">
             Filtered by: {VOTE_LABELS[statsFilter] || statsFilter}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const STATUS_COLORS: Record<string, string> = {
   processing: "bg-blue-900/50 text-blue-300",
   pending: "bg-orange-900/50 text-orange-300",
   unknown: "bg-gray-800 text-gray-400",
+  removed: "bg-red-900/50 text-red-300 line-through",
 };
 
 export const VOTE_COLORS: Record<string, string> = {
@@ -25,8 +26,16 @@ export const COMMUNITY_VOTE_COLORS: Record<string, string> = {
   remove: "bg-red-600",
 };
 
+export const SORT_LABELS: Record<string, string> = {
+  title_asc: "Title (A-Z)",
+  title_desc: "Title (Z-A)",
+  requested_newest: "Date Requested (Newest)",
+  requested_oldest: "Date Requested (Oldest)",
+};
+
 export const COMMUNITY_SORT_LABELS: Record<string, string> = {
   most_remove: "Most Votes to Remove",
   oldest_unwatched: "Oldest Unwatched",
   newest: "Recently Nominated",
+  ...SORT_LABELS,
 };

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -28,7 +28,7 @@ export const mediaItems = sqliteTable("media_items", {
   title: text("title").notNull(),
   posterPath: text("poster_path"),
   status: text("status", {
-    enum: ["unknown", "pending", "processing", "partial", "available"],
+    enum: ["unknown", "pending", "processing", "partial", "available", "removed"],
   })
     .default("unknown")
     .notNull(),

--- a/src/lib/db/sorting.ts
+++ b/src/lib/db/sorting.ts
@@ -1,0 +1,28 @@
+import { asc, desc, type SQL } from "drizzle-orm";
+import { mediaItems } from "./schema";
+
+export const COMMON_SORTS = [
+  "title_asc",
+  "title_desc",
+  "requested_newest",
+  "requested_oldest",
+] as const;
+export type CommonSort = (typeof COMMON_SORTS)[number];
+
+/** Default sort used as fallback when no sort matches */
+export const DEFAULT_SORT_ORDER = asc(mediaItems.title);
+
+export function getCommonSortOrder(sortKey: string): SQL | null {
+  switch (sortKey) {
+    case "title_asc":
+      return asc(mediaItems.title);
+    case "title_desc":
+      return desc(mediaItems.title);
+    case "requested_newest":
+      return desc(mediaItems.requestedAt);
+    case "requested_oldest":
+      return asc(mediaItems.requestedAt);
+    default:
+      return null;
+  }
+}

--- a/src/lib/validators/__tests__/schemas.test.ts
+++ b/src/lib/validators/__tests__/schemas.test.ts
@@ -101,6 +101,7 @@ describe("mediaQuerySchema", () => {
       type: "all",
       status: "all",
       vote: "all",
+      sort: "title_asc",
       page: 1,
       limit: 20,
     });
@@ -162,7 +163,15 @@ describe("mediaQuerySchema", () => {
   });
 
   it("accepts all valid status values", () => {
-    for (const status of ["available", "pending", "processing", "partial", "unknown", "all"]) {
+    for (const status of [
+      "available",
+      "pending",
+      "processing",
+      "partial",
+      "unknown",
+      "removed",
+      "all",
+    ]) {
       expect(mediaQuerySchema.parse({ status }).status).toBe(status);
     }
   });
@@ -180,6 +189,16 @@ describe("mediaQuerySchema", () => {
 
   it("rejects search > 200 chars", () => {
     expect(() => mediaQuerySchema.parse({ search: "a".repeat(201) })).toThrow();
+  });
+
+  it("accepts all valid sort values", () => {
+    for (const sort of ["title_asc", "title_desc", "requested_newest", "requested_oldest"]) {
+      expect(mediaQuerySchema.parse({ sort }).sort).toBe(sort);
+    }
+  });
+
+  it("rejects invalid sort value", () => {
+    expect(() => mediaQuerySchema.parse({ sort: "invalid" })).toThrow();
   });
 });
 
@@ -226,6 +245,12 @@ describe("communityQuerySchema", () => {
 
   it("accepts unvoted='true'", () => {
     expect(communityQuerySchema.parse({ unvoted: "true" }).unvoted).toBe("true");
+  });
+
+  it("accepts common sort values", () => {
+    for (const sort of ["title_asc", "title_desc", "requested_newest", "requested_oldest"]) {
+      expect(communityQuerySchema.parse({ sort }).sort).toBe(sort);
+    }
   });
 
   it("rejects invalid sort value", () => {

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { COMMON_SORTS } from "@/lib/db/sorting";
 
 export const voteSchema = z
   .object({
@@ -17,11 +18,12 @@ export const syncRequestSchema = z.object({
 export const mediaQuerySchema = z.object({
   type: z.enum(["movie", "tv", "all"]).default("all"),
   status: z
-    .enum(["available", "pending", "processing", "partial", "unknown", "all"])
+    .enum(["available", "pending", "processing", "partial", "unknown", "removed", "all"])
     .default("all"),
   vote: z.enum(["keep", "delete", "trim", "none", "all"]).default("all"),
   search: z.string().max(200).optional(),
   watched: z.enum(["true", "false", ""]).optional(),
+  sort: z.enum(COMMON_SORTS).default("title_asc"),
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().max(100).default(20),
 });
@@ -33,7 +35,9 @@ export const communityVoteSchema = z.object({
 export const communityQuerySchema = z.object({
   type: z.enum(["movie", "tv", "all"]).default("all"),
   unvoted: z.enum(["true", "false", ""]).optional(),
-  sort: z.enum(["most_remove", "oldest_unwatched", "newest"]).default("most_remove"),
+  sort: z
+    .enum(["most_remove", "oldest_unwatched", "newest", ...COMMON_SORTS])
+    .default("most_remove"),
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().max(100).default(20),
 });

--- a/src/test/helpers/db.ts
+++ b/src/test/helpers/db.ts
@@ -30,7 +30,7 @@ export function createTestDb() {
       media_type TEXT NOT NULL CHECK(media_type IN ('movie', 'tv')),
       title TEXT NOT NULL,
       poster_path TEXT,
-      status TEXT NOT NULL DEFAULT 'unknown' CHECK(status IN ('unknown', 'pending', 'processing', 'partial', 'available')),
+      status TEXT NOT NULL DEFAULT 'unknown' CHECK(status IN ('unknown', 'pending', 'processing', 'partial', 'available', 'removed')),
       requested_by_plex_id TEXT REFERENCES users(plex_id),
       requested_at TEXT,
       rating_key TEXT,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,7 +36,13 @@ export type NewReviewAction = typeof reviewActions.$inferInsert;
 export type VoteValue = "keep" | "delete" | "trim";
 export type CommunityVoteValue = "keep" | "remove";
 export type MediaType = "movie" | "tv";
-export type MediaStatus = "unknown" | "pending" | "processing" | "partial" | "available";
+export type MediaStatus =
+  | "unknown"
+  | "pending"
+  | "processing"
+  | "partial"
+  | "available"
+  | "removed";
 export type SyncType = "overseerr" | "tautulli" | "full";
 export type SyncStatus = "running" | "completed" | "failed";
 


### PR DESCRIPTION
…nity

Add shared sort utility (sorting.ts) with 4 common sort options (title A-Z/Z-A, date requested newest/oldest) used by media, community, and admin community routes. Add sort dropdown to media grid. Mark stale Overseerr items as "removed" with safety guard against empty API responses. Show removed items in community views with voting disabled and red "Removed from library" banner. Fix admin community route to respect sort param instead of ignoring it.