### PR TITLE
fix: improve stats accuracy and real-time updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ npm test -- --watch      # Run tests in watch mode
 
 ### Data Access
 
-- The media endpoint supports a `scope` param: `scope=all` (default) shows all users' library items; `scope=personal` filters to only the current user's requests
+- The media endpoint supports a `scope` param: `scope=personal` (default) filters to only the current user's requests; `scope=all` shows all users' library items
 - Vote and watch status data is always scoped to the current user via LEFT JOINs — users never see other users' votes
 - Write endpoints (`POST /api/media/[id]/vote`) enforce ownership — non-admins can only vote on their own items
 - Admins can nominate (delete/trim) ANY user's content — this is an intentional privilege for curating the library

--- a/src/app/api/media/__tests__/route.test.ts
+++ b/src/app/api/media/__tests__/route.test.ts
@@ -48,14 +48,15 @@ const userSession = { userId: 1, plexId: "plex-user-1", username: "testuser", is
 const otherSession = { userId: 2, plexId: "plex-user-2", username: "otheruser", isAdmin: false };
 
 describe("GET /api/media", () => {
-  it("defaults to scope=all, returning all users' items", async () => {
+  it("defaults to scope=personal, returning only user's own items", async () => {
     mockRequireAuth.mockResolvedValue(userSession);
     const req = createRequest("http://localhost:3000/api/media");
     const res = await GET(req);
     const data = await res.json();
 
     expect(res.status).toBe(200);
-    expect(data.items.length).toBe(7);
+    expect(data.items.length).toBe(6);
+    expect(data.items.every((i: any) => i.id !== 5)).toBe(true);
   });
 
   it("scope=personal returns only user's own items", async () => {

--- a/src/app/api/media/stats/__tests__/route.test.ts
+++ b/src/app/api/media/stats/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestDb, seedTestData } from "@/test/helpers/db";
+import { createRequest } from "@/test/helpers/request";
+import { NextResponse } from "next/server";
+
+const mockRequireAuth = vi.fn();
+
+class AuthError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function handleAuthError(error: unknown) {
+  if (error instanceof AuthError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+  return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+}
+
+vi.mock("@/lib/auth/middleware", () => ({
+  requireAuth: () => mockRequireAuth(),
+  requireAdmin: vi.fn(),
+  handleAuthError: (error: unknown) => handleAuthError(error),
+  AuthError,
+}));
+
+let testDb: ReturnType<typeof createTestDb>;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb.db;
+  },
+}));
+
+const { GET } = await import("../route");
+
+beforeEach(() => {
+  testDb = createTestDb();
+  seedTestData(testDb.db);
+  mockRequireAuth.mockReset();
+});
+
+const userSession = { userId: 1, plexId: "plex-user-1", username: "testuser", isAdmin: false };
+const otherSession = { userId: 2, plexId: "plex-user-2", username: "otheruser", isAdmin: false };
+
+describe("GET /api/media/stats", () => {
+  it("defaults to personal scope stats", async () => {
+    mockRequireAuth.mockResolvedValue(userSession);
+    const req = createRequest("http://localhost:3000/api/media/stats");
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    // plex-user-1 has 6 items, 2 nominated (items 2,7), 1 watched (item 1)
+    expect(data.total).toBe(6);
+    expect(data.nominated).toBe(2);
+    expect(data.notNominated).toBe(4);
+    expect(data.watched).toBe(1);
+  });
+
+  it("returns all-scope stats when scope=all", async () => {
+    mockRequireAuth.mockResolvedValue(userSession);
+    const req = createRequest("http://localhost:3000/api/media/stats?scope=all");
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    // 7 total items, plex-user-1 nominated 2, watched 1
+    expect(data.total).toBe(7);
+    expect(data.nominated).toBe(2);
+    expect(data.notNominated).toBe(5);
+    expect(data.watched).toBe(1);
+  });
+
+  it("returns correct stats for a different user (personal)", async () => {
+    mockRequireAuth.mockResolvedValue(otherSession);
+    const req = createRequest("http://localhost:3000/api/media/stats?scope=personal");
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    // plex-user-2 has 1 item (id 5), nominated it, watched it
+    expect(data.total).toBe(1);
+    expect(data.nominated).toBe(1);
+    expect(data.notNominated).toBe(0);
+    expect(data.watched).toBe(1);
+  });
+
+  it("returns correct stats for a different user (all)", async () => {
+    mockRequireAuth.mockResolvedValue(otherSession);
+    const req = createRequest("http://localhost:3000/api/media/stats?scope=all");
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    // 7 total, plex-user-2 nominated 1 (item 5), watched 1 (item 5)
+    expect(data.total).toBe(7);
+    expect(data.nominated).toBe(1);
+    expect(data.notNominated).toBe(6);
+    expect(data.watched).toBe(1);
+  });
+
+  it("excludes removed items from stats", async () => {
+    mockRequireAuth.mockResolvedValue(userSession);
+    // Mark an item as removed
+    const sqlite = (testDb.db as any).session.client;
+    sqlite.exec(`UPDATE media_items SET status = 'removed' WHERE id = 1`);
+
+    const req = createRequest("http://localhost:3000/api/media/stats?scope=personal");
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.total).toBe(5);
+  });
+
+  it("returns zeroes for a user with no items", async () => {
+    const emptySession = { userId: 3, plexId: "plex-admin", username: "adminuser", isAdmin: true };
+    mockRequireAuth.mockResolvedValue(emptySession);
+    const req = createRequest("http://localhost:3000/api/media/stats?scope=personal");
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.total).toBe(0);
+    expect(data.nominated).toBe(0);
+    expect(data.notNominated).toBe(0);
+    expect(data.watched).toBe(0);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError("Not authenticated", 401));
+    const req = createRequest("http://localhost:3000/api/media/stats");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/media/stats/route.ts
+++ b/src/app/api/media/stats/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, handleAuthError } from "@/lib/auth/middleware";
+import { computeMediaStats } from "@/lib/db/queries";
+import { statsQuerySchema } from "@/lib/validators/schemas";
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await requireAuth();
+
+    const params = Object.fromEntries(request.nextUrl.searchParams);
+    const query = statsQuerySchema.parse(params);
+
+    const stats = await computeMediaStats(session.plexId, query.scope);
+
+    return NextResponse.json(stats);
+  } catch (error) {
+    return handleAuthError(error);
+  }
+}

--- a/src/components/community/CommunityCard.tsx
+++ b/src/components/community/CommunityCard.tsx
@@ -85,7 +85,7 @@ export function CommunityCard({ item, onVoteChange, onSelfVoteChange }: Communit
         ) : (
           <>
             <VoteTallyBar keepCount={item.tally.keepCount} />
-            {item.isRequestor || item.isNominator ? (
+            {item.isNominator ? (
               <div className="space-y-1">
                 <p className="text-xs text-gray-500">Your nomination — change your vote:</p>
                 <VoteButton
@@ -95,6 +95,15 @@ export function CommunityCard({ item, onVoteChange, onSelfVoteChange }: Communit
                   mediaType={item.mediaType}
                   currentKeepSeasons={item.keepSeasons}
                   onVoteChange={(newVote: VoteValue | null) => onSelfVoteChange?.(item.id, newVote)}
+                />
+              </div>
+            ) : item.isRequestor ? (
+              <div className="space-y-1">
+                <p className="text-xs text-amber-400">Admin nomination</p>
+                <CommunityVoteButton
+                  mediaItemId={item.id}
+                  currentVote={item.currentUserVote}
+                  onVoteChange={(vote, delta) => onVoteChange?.(item.id, vote, delta)}
                 />
               </div>
             ) : (

--- a/src/components/community/CommunityContent.tsx
+++ b/src/components/community/CommunityContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import { CommunityGrid } from "./CommunityGrid";
 
 interface CommunityContentProps {
@@ -9,10 +10,23 @@ interface CommunityContentProps {
 }
 
 export function CommunityContent({
-  totalCandidates,
-  totalVotes,
+  totalCandidates: initialCandidates,
+  totalVotes: initialVotes,
   activeRound,
 }: CommunityContentProps) {
+  const [stats, setStats] = useState({
+    candidates: initialCandidates,
+    votes: initialVotes,
+  });
+
+  const handleCandidateRemoved = useCallback(() => {
+    setStats((prev) => ({ ...prev, candidates: prev.candidates - 1 }));
+  }, []);
+
+  const handleCommunityVoteChange = useCallback((delta: number) => {
+    setStats((prev) => ({ ...prev, votes: prev.votes + delta }));
+  }, []);
+
   return (
     <div className="space-y-6">
       {activeRound && (
@@ -31,14 +45,17 @@ export function CommunityContent({
       <div className="grid grid-cols-2 gap-4">
         <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
           <p className="text-xs tracking-wide text-gray-500 uppercase">Up for Review</p>
-          <p className="mt-1 text-2xl font-bold">{totalCandidates}</p>
+          <p className="mt-1 text-2xl font-bold">{stats.candidates}</p>
         </div>
         <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
           <p className="text-xs tracking-wide text-gray-500 uppercase">Community Votes</p>
-          <p className="mt-1 text-2xl font-bold">{totalVotes}</p>
+          <p className="mt-1 text-2xl font-bold">{stats.votes}</p>
         </div>
       </div>
-      <CommunityGrid />
+      <CommunityGrid
+        onCandidateRemoved={handleCandidateRemoved}
+        onCommunityVoteChange={handleCommunityVoteChange}
+      />
     </div>
   );
 }

--- a/src/components/community/CommunityGrid.tsx
+++ b/src/components/community/CommunityGrid.tsx
@@ -7,7 +7,12 @@ import { MediaCardSkeleton } from "../ui/MediaCardSkeleton";
 import { COMMUNITY_SORT_LABELS } from "@/lib/constants";
 import type { CommunityCandidate, CommunityVoteValue, VoteValue } from "@/types";
 
-export function CommunityGrid() {
+interface CommunityGridProps {
+  onCandidateRemoved?: () => void;
+  onCommunityVoteChange?: (delta: number) => void;
+}
+
+export function CommunityGrid({ onCandidateRemoved, onCommunityVoteChange }: CommunityGridProps) {
   const [items, setItems] = useState<CommunityCandidate[]>([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -72,6 +77,7 @@ export function CommunityGrid() {
           : item
       )
     );
+    onCommunityVoteChange?.(delta.keep);
   };
 
   const handleSelfVoteChange = (itemId: number, vote: VoteValue | null) => {
@@ -79,6 +85,7 @@ export function CommunityGrid() {
       // User un-nominated — remove from community list
       setItems((prev) => prev.filter((item) => item.id !== itemId));
       setTotalItems((prev) => prev - 1);
+      onCandidateRemoved?.();
     } else {
       // Updated to delete/trim — update the nomination type in place
       setItems((prev) =>

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { UserStats } from "./UserStats";
 import { MediaGrid } from "../media/MediaGrid";
 import type { VoteValue } from "@/types";
@@ -13,34 +13,74 @@ interface DashboardContentProps {
 }
 
 export function DashboardContent({
-  totalRequests,
+  totalRequests: initialTotal,
   nominatedCount: initialNominated,
   notNominatedCount: initialNotNominated,
-  watchedCount,
+  watchedCount: initialWatched,
 }: DashboardContentProps) {
   const [statsFilter, setStatsFilter] = useState<string | null>(null);
+  const [scope, setScope] = useState("personal");
   const [stats, setStats] = useState({
+    total: initialTotal,
     nominated: initialNominated,
     notNominated: initialNotNominated,
+    watched: initialWatched,
   });
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const statsVersionRef = useRef(0);
+
+  const fetchStats = useCallback(async (newScope: string) => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    const versionAtStart = statsVersionRef.current;
+
+    try {
+      const res = await fetch(`/api/media/stats?scope=${newScope}`, {
+        signal: controller.signal,
+      });
+      if (res.ok) {
+        const data = await res.json();
+        // Only apply if no votes occurred during the fetch
+        if (statsVersionRef.current === versionAtStart) {
+          setStats({
+            total: data.total,
+            nominated: data.nominated,
+            notNominated: data.notNominated,
+            watched: data.watched,
+          });
+        }
+      }
+    } catch {
+      // Keep existing stats on error (including abort)
+    }
+  }, []);
+
+  const handleScopeChange = useCallback(
+    (newScope: string) => {
+      setScope(newScope);
+      setStatsFilter(null);
+      fetchStats(newScope);
+    },
+    [fetchStats]
+  );
 
   const handleVoteChange = useCallback(
     (_itemId: number, oldVote: VoteValue | null, newVote: VoteValue | null) => {
+      statsVersionRef.current++;
       setStats((prev) => {
         const next = { ...prev };
         const wasNominated = oldVote === "delete" || oldVote === "trim";
         const isNominated = newVote === "delete" || newVote === "trim";
 
         if (wasNominated && !isNominated) {
-          // Un-nominating
           next.nominated--;
           next.notNominated++;
         } else if (!wasNominated && isNominated) {
-          // Nominating
           next.nominated++;
           next.notNominated--;
         }
-        // delete -> trim or trim -> delete: no stat change
 
         return next;
       });
@@ -51,16 +91,22 @@ export function DashboardContent({
   return (
     <>
       <UserStats
-        totalRequests={totalRequests}
+        totalRequests={stats.total}
         nominatedCount={stats.nominated}
         notNominatedCount={stats.notNominated}
-        watchedCount={watchedCount}
+        watchedCount={stats.watched}
         activeFilter={statsFilter}
         onFilterChange={setStatsFilter}
       />
       <div>
-        <h2 className="mb-4 text-lg font-semibold">Your Requests</h2>
-        <MediaGrid statsFilter={statsFilter} onVoteChange={handleVoteChange} />
+        <h2 className="mb-4 text-lg font-semibold">
+          {scope === "personal" ? "Your Requests" : "All Users\u2019 Requests"}
+        </h2>
+        <MediaGrid
+          statsFilter={statsFilter}
+          onVoteChange={handleVoteChange}
+          onScopeChange={handleScopeChange}
+        />
       </div>
     </>
   );

--- a/src/lib/validators/__tests__/schemas.test.ts
+++ b/src/lib/validators/__tests__/schemas.test.ts
@@ -92,7 +92,7 @@ describe("mediaQuerySchema", () => {
   it("applies all defaults for empty input", () => {
     const result = mediaQuerySchema.parse({});
     expect(result).toEqual({
-      scope: "all",
+      scope: "personal",
       type: "all",
       status: "all",
       vote: "all",

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -11,12 +11,16 @@ export const voteSchema = z
     path: ["keepSeasons"],
   });
 
+export const statsQuerySchema = z.object({
+  scope: z.enum(["personal", "all"]).default("personal"),
+});
+
 export const syncRequestSchema = z.object({
   type: z.enum(["overseerr", "tautulli", "full"]).default("full"),
 });
 
 export const mediaQuerySchema = z.object({
-  scope: z.enum(["personal", "all"]).default("all"),
+  scope: z.enum(["personal", "all"]).default("personal"),
   type: z.enum(["movie", "tv", "all"]).default("all"),
   status: z
     .enum(["available", "pending", "processing", "partial", "unknown", "removed", "all"])
@@ -63,6 +67,7 @@ export const syncScheduleSchema = z.object({
   syncType: z.enum(["overseerr", "tautulli", "full"]).default("full"),
 });
 
+export type StatsQuery = z.infer<typeof statsQuerySchema>;
 export type VoteInput = z.infer<typeof voteSchema>;
 export type SyncRequest = z.infer<typeof syncRequestSchema>;
 export type MediaQuery = z.infer<typeof mediaQuerySchema>;


### PR DESCRIPTION
## Summary
- **DRY refactor**: Extracted shared `computeMediaStats()` helper in `lib/db/queries.ts` — eliminates ~30 lines of duplicated stats queries between the dashboard page and stats API endpoint
- **Critical fix**: Admin nominations on the community page were misattributed to the requestor, allowing false un-nominations that hid items client-side while the admin's nomination persisted in the DB. Now shows "Admin nomination" label without un-nominate button
- **Race condition fixes**: Added AbortController to `fetchStats` (prevents stale scope responses) and a version counter (prevents fetch responses from overwriting optimistic vote updates)
- **Stale grid fix**: Media grid now refetches after voting when a stats filter is active, so items that no longer match the filter are removed immediately
- **Community stats**: Wired candidate count and vote tally to update on user actions (un-nominate, community vote)
- **Default scope**: Changed default scope from "all" to "personal" for consistent dashboard experience
- **Schema cleanup**: Moved inline `statsQuerySchema` to shared `validators/schemas.ts`

## Test plan
- [x] All 315 tests pass (including 1 new edge-case test for stats with no items)
- [ ] Verify admin nomination shows "Admin nomination" label on community page
- [ ] Verify un-nominating an item while "Nominated" filter is active removes it from grid
- [ ] Verify rapid scope switching shows correct stats (no stale data flash)
- [ ] Verify voting while scope fetch is in-flight doesn't revert optimistic update

🤖 Generated with [Claude Code](https://claude.com/claude-code)