### PR TITLE
feat: enhance admin review panel and show available season counts

### DIFF
--- a/src/app/api/admin/review-rounds/[id]/route.ts
+++ b/src/app/api/admin/review-rounds/[id]/route.ts
@@ -70,6 +70,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
         status: mediaItems.status,
         requestedByUsername: users.username,
         seasonCount: mediaItems.seasonCount,
+        availableSeasonCount: mediaItems.availableSeasonCount,
         nominationType: selfPreferredVote,
         keepSeasons: selfPreferredKeepSeasons,
         keepCount: keepCountSub.cnt,
@@ -92,6 +93,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
         status: c.status,
         requestedByUsername: c.requestedByUsername || "Unknown",
         seasonCount: c.seasonCount || null,
+        availableSeasonCount: c.availableSeasonCount || null,
         nominationType: (c.nominationType === "trim" ? "trim" : "delete") as "delete" | "trim",
         keepSeasons: c.keepSeasons ? Number(c.keepSeasons) : null,
         tally: {

--- a/src/app/api/community/route.ts
+++ b/src/app/api/community/route.ts
@@ -108,6 +108,7 @@ export async function GET(request: NextRequest) {
         requestedAt: mediaItems.requestedAt,
         requestedByUsername: users.username,
         seasonCount: mediaItems.seasonCount,
+        availableSeasonCount: mediaItems.availableSeasonCount,
         nominationType: selfPreferredVote,
         keepSeasons: selfPreferredKeepSeasons,
         watched: watchStatus.watched,
@@ -180,6 +181,7 @@ export async function GET(request: NextRequest) {
         requestedByUsername: i.requestedByUsername || "Unknown",
         requestedAt: i.requestedAt,
         seasonCount: i.seasonCount || null,
+        availableSeasonCount: i.availableSeasonCount || null,
         nominationType: (i.nominationType === "trim" ? "trim" : "delete") as "delete" | "trim",
         keepSeasons: i.keepSeasons ? Number(i.keepSeasons) : null,
         watchStatus:

--- a/src/components/admin/ReviewRoundPanel.tsx
+++ b/src/components/admin/ReviewRoundPanel.tsx
@@ -14,6 +14,7 @@ export interface RoundCandidate {
   status: MediaStatus;
   requestedByUsername: string;
   seasonCount: number | null;
+  availableSeasonCount: number | null;
   nominationType: "delete" | "trim";
   keepSeasons: number | null;
   tally: { keepCount: number };
@@ -169,11 +170,17 @@ export function ReviewRoundPanel({ round, onClosed }: ReviewRoundPanelProps) {
                   <MediaTypeBadge mediaType={c.mediaType} />
                 </div>
                 <p className="text-sm text-gray-400">by {c.requestedByUsername}</p>
-                {c.nominationType === "trim" && c.keepSeasons && c.seasonCount && (
+                {c.nominationType === "trim" && c.keepSeasons && c.seasonCount ? (
                   <p className="text-xs text-amber-400">
                     Trim to latest {c.keepSeasons} of {c.seasonCount} seasons
                   </p>
-                )}
+                ) : c.mediaType === "tv" && c.seasonCount && c.seasonCount > 1 ? (
+                  <p className="text-xs text-gray-500">
+                    {c.availableSeasonCount && c.availableSeasonCount !== c.seasonCount
+                      ? `${c.availableSeasonCount} of ${c.seasonCount} seasons`
+                      : `${c.seasonCount} seasons`}
+                  </p>
+                ) : null}
                 {c.status === "removed" ? (
                   <div className="mt-2 inline-block rounded bg-red-900/30 px-3 py-1 text-sm font-medium text-red-400">
                     Removed from library

--- a/src/components/admin/__tests__/ReviewRoundPanel.test.ts
+++ b/src/components/admin/__tests__/ReviewRoundPanel.test.ts
@@ -9,6 +9,7 @@ const candidate = (
   status: "available",
   requestedByUsername: "user",
   seasonCount: null,
+  availableSeasonCount: null,
   nominationType: "delete",
   keepSeasons: null,
   tally: { keepCount: 0 },

--- a/src/components/community/CommunityCard.tsx
+++ b/src/components/community/CommunityCard.tsx
@@ -66,7 +66,11 @@ export function CommunityCard({ item, onVoteChange, onSelfVoteChange }: Communit
             Trim: keep latest {item.keepSeasons} of {item.seasonCount} seasons
           </p>
         ) : item.seasonCount && item.seasonCount > 1 ? (
-          <p className="text-xs text-gray-500">{item.seasonCount} seasons</p>
+          <p className="text-xs text-gray-500">
+            {item.availableSeasonCount && item.availableSeasonCount !== item.seasonCount
+              ? `${item.availableSeasonCount} of ${item.seasonCount} seasons`
+              : `${item.seasonCount} seasons`}
+          </p>
         ) : null}
         <p className="text-xs text-gray-400">Requested by: {item.requestedByUsername}</p>
         {item.watchStatus && (

--- a/src/components/media/MediaCard.tsx
+++ b/src/components/media/MediaCard.tsx
@@ -57,7 +57,11 @@ export function MediaCard({ item, onVoteChange }: MediaCardProps) {
           {item.title}
         </h3>
         {item.mediaType === "tv" && item.seasonCount && item.seasonCount > 1 && (
-          <p className="text-xs text-gray-500">{item.seasonCount} seasons</p>
+          <p className="text-xs text-gray-500">
+            {item.availableSeasonCount && item.availableSeasonCount !== item.seasonCount
+              ? `${item.availableSeasonCount} of ${item.seasonCount} seasons`
+              : `${item.seasonCount} seasons`}
+          </p>
         )}
         {item.vote === "trim" && item.keepSeasons && item.seasonCount && (
           <p className="text-xs text-amber-400">

--- a/src/lib/db/migrations/0005_new_celestials.sql
+++ b/src/lib/db/migrations/0005_new_celestials.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `media_items` ADD `available_season_count` integer;

--- a/src/lib/db/migrations/meta/0005_snapshot.json
+++ b/src/lib/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,802 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b25eb7ee-3b9c-4064-bc8d-a00fa5bebe0c",
+  "prevId": "6ad628e0-4eac-4caa-99b4-52149f99c53d",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_votes": {
+      "name": "community_votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_plex_id": {
+          "name": "user_plex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote": {
+          "name": "vote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "community_votes_media_user_idx": {
+          "name": "community_votes_media_user_idx",
+          "columns": [
+            "media_item_id",
+            "user_plex_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_votes_media_item_id_media_items_id_fk": {
+          "name": "community_votes_media_item_id_media_items_id_fk",
+          "tableFrom": "community_votes",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_votes_user_plex_id_users_plex_id_fk": {
+          "name": "community_votes_user_plex_id_users_plex_id_fk",
+          "tableFrom": "community_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_plex_id"
+          ],
+          "columnsTo": [
+            "plex_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "overseerr_id": {
+          "name": "overseerr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overseerr_request_id": {
+          "name": "overseerr_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "requested_by_plex_id": {
+          "name": "requested_by_plex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_count": {
+          "name": "season_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_season_count": {
+          "name": "available_season_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "media_items_overseerr_id_unique": {
+          "name": "media_items_overseerr_id_unique",
+          "columns": [
+            "overseerr_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_items_requested_by_plex_id_users_plex_id_fk": {
+          "name": "media_items_requested_by_plex_id_users_plex_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_plex_id"
+          ],
+          "columnsTo": [
+            "plex_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "review_actions": {
+      "name": "review_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_round_id": {
+          "name": "review_round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acted_at": {
+          "name": "acted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "acted_by_plex_id": {
+          "name": "acted_by_plex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "review_actions_round_item_idx": {
+          "name": "review_actions_round_item_idx",
+          "columns": [
+            "review_round_id",
+            "media_item_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "review_actions_review_round_id_review_rounds_id_fk": {
+          "name": "review_actions_review_round_id_review_rounds_id_fk",
+          "tableFrom": "review_actions",
+          "tableTo": "review_rounds",
+          "columnsFrom": [
+            "review_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_actions_media_item_id_media_items_id_fk": {
+          "name": "review_actions_media_item_id_media_items_id_fk",
+          "tableFrom": "review_actions",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_actions_acted_by_plex_id_users_plex_id_fk": {
+          "name": "review_actions_acted_by_plex_id_users_plex_id_fk",
+          "tableFrom": "review_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acted_by_plex_id"
+          ],
+          "columnsTo": [
+            "plex_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "review_rounds": {
+      "name": "review_rounds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_plex_id": {
+          "name": "created_by_plex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_rounds_created_by_plex_id_users_plex_id_fk": {
+          "name": "review_rounds_created_by_plex_id_users_plex_id_fk",
+          "tableFrom": "review_rounds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_plex_id"
+          ],
+          "columnsTo": [
+            "plex_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_log": {
+      "name": "sync_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items_synced": {
+          "name": "items_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_votes": {
+      "name": "user_votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_plex_id": {
+          "name": "user_plex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote": {
+          "name": "vote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keep_seasons": {
+          "name": "keep_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "user_votes_media_user_idx": {
+          "name": "user_votes_media_user_idx",
+          "columns": [
+            "media_item_id",
+            "user_plex_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_votes_media_item_id_media_items_id_fk": {
+          "name": "user_votes_media_item_id_media_items_id_fk",
+          "tableFrom": "user_votes",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_votes_user_plex_id_users_plex_id_fk": {
+          "name": "user_votes_user_plex_id_users_plex_id_fk",
+          "tableFrom": "user_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_plex_id"
+          ],
+          "columnsTo": [
+            "plex_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_plex_id_unique": {
+          "name": "users_plex_id_unique",
+          "columns": [
+            "plex_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watch_status": {
+      "name": "watch_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_plex_id": {
+          "name": "user_plex_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched": {
+          "name": "watched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_watched_at": {
+          "name": "last_watched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watch_status_media_item_id_media_items_id_fk": {
+          "name": "watch_status_media_item_id_media_items_id_fk",
+          "tableFrom": "watch_status",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "watch_status_user_plex_id_users_plex_id_fk": {
+          "name": "watch_status_user_plex_id_users_plex_id_fk",
+          "tableFrom": "watch_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_plex_id"
+          ],
+          "columnsTo": [
+            "plex_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1770751691225,
       "tag": "0004_acoustic_payback",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1770914530730,
+      "tag": "0005_new_celestials",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -14,6 +14,7 @@ const mediaItemColumns = {
   requestedAt: mediaItems.requestedAt,
   ratingKey: mediaItems.ratingKey,
   seasonCount: mediaItems.seasonCount,
+  availableSeasonCount: mediaItems.availableSeasonCount,
   vote: userVotes.vote,
   keepSeasons: userVotes.keepSeasons,
   watched: watchStatus.watched,
@@ -64,6 +65,7 @@ export function mapMediaItemRow(
     requestedAt: i.requestedAt,
     ratingKey: i.ratingKey,
     seasonCount: i.seasonCount || null,
+    availableSeasonCount: i.availableSeasonCount || null,
     vote: i.vote || null,
     keepSeasons: i.keepSeasons || null,
     watchStatus:

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -36,6 +36,7 @@ export const mediaItems = sqliteTable("media_items", {
   requestedAt: text("requested_at"),
   ratingKey: text("rating_key"),
   seasonCount: integer("season_count"),
+  availableSeasonCount: integer("available_season_count"),
   lastSyncedAt: text("last_synced_at"),
   createdAt: text("created_at")
     .default(sql`(datetime('now'))`)

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -77,6 +77,18 @@ const overseerrMediaDetailSchema = z.object({
       imdbId: z.string().nullish(),
     })
     .nullish(),
+  mediaInfo: z
+    .object({
+      seasons: z
+        .array(
+          z.object({
+            seasonNumber: z.number(),
+            status: z.number(),
+          })
+        )
+        .nullish(),
+    })
+    .nullish(),
 });
 
 export type OverseerrRequest = z.infer<typeof overseerrRequestSchema>;

--- a/src/test/helpers/db.ts
+++ b/src/test/helpers/db.ts
@@ -35,6 +35,7 @@ export function createTestDb() {
       requested_at TEXT,
       rating_key TEXT,
       season_count INTEGER,
+      available_season_count INTEGER,
       last_synced_at TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,7 @@ export interface CommunityCandidate {
   requestedByUsername: string;
   requestedAt: string | null;
   seasonCount: number | null;
+  availableSeasonCount: number | null;
   nominationType: "delete" | "trim";
   keepSeasons: number | null;
   watchStatus: {


### PR DESCRIPTION
## Summary

- **Admin review round sorting**: Sort candidates by keep votes, title, or media type with asc/desc options via dropdown
- **"Most Keep Votes" community sort**: New sort option on the community page, complementing the existing "Fewest Keep Votes"
- **Available season count**: Parse Overseerr's `mediaInfo.seasons` to show "X of Y seasons" on TV cards when only some seasons are downloaded (e.g., "4 of 50 seasons"). Falls back to "50 seasons" when all are present.
- **Type safety improvements**: Sort enums use `as const` tuples with `Record<Sort, string>` label maps for compile-time exhaustiveness

## Test plan

- [x] `bun run build` passes with no type errors
- [x] `npm test` — 325 tests pass (3 new sync tests + 7 new sort tests)
- [x] Migration 0005 generated and applied
- [x] Manual: synced server, verified TV cards show "X of Y seasons" for partially downloaded shows
- [x] Manual: verified cards show just "Y seasons" when all seasons are present
- [x] Manual: verified admin review round sorting works across all 6 sort options

🤖 Generated with [Claude Code](https://claude.com/claude-code)