### PR TITLE
feat: admin review round editing, export, and enhanced candidate cards

### DIFF
--- a/src/app/api/admin/review-rounds/[id]/export/route.ts
+++ b/src/app/api/admin/review-rounds/[id]/export/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, handleAuthError } from "@/lib/auth/middleware";
+import { db } from "@/lib/db";
+import { getCandidatesForRound } from "@/lib/db/queries";
+import { reviewRounds } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n") || value.includes("\r")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toCsvRow(fields: string[]): string {
+  return fields.map(escapeCsvField).join(",");
+}
+
+const CSV_HEADERS = [
+  "Title",
+  "Type",
+  "Status",
+  "Requested By",
+  "Nomination",
+  "Keep Seasons",
+  "Season Count",
+  "Community Keep Votes",
+  "Admin Action",
+  "Action By",
+  "Action Date",
+];
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdmin();
+    const { id } = await params;
+    const roundId = Number(id);
+
+    if (isNaN(roundId)) {
+      return NextResponse.json({ error: "Invalid round ID" }, { status: 400 });
+    }
+
+    const round = await db.select().from(reviewRounds).where(eq(reviewRounds.id, roundId)).limit(1);
+
+    if (round.length === 0) {
+      return NextResponse.json({ error: "Review round not found" }, { status: 404 });
+    }
+
+    const candidates = await getCandidatesForRound(roundId);
+
+    const rows = candidates.map((c) =>
+      toCsvRow([
+        c.title,
+        c.mediaType,
+        c.status,
+        c.requestedByUsername || "Unknown",
+        c.nominationType === "trim" ? "trim" : "delete",
+        c.keepSeasons ? String(c.keepSeasons) : "",
+        c.seasonCount ? String(c.seasonCount) : "",
+        String(c.keepCount ?? 0),
+        c.action || "",
+        c.actionByUsername || "",
+        c.actedAt || "",
+      ])
+    );
+
+    const csv = [toCsvRow(CSV_HEADERS), ...rows].join("\n");
+    const filename = round[0].name.replace(/[^a-zA-Z0-9 _-]/g, "").trim() || "export";
+
+    return new NextResponse(csv, {
+      headers: {
+        "Content-Type": "text/csv",
+        "Content-Disposition": `attachment; filename="${filename}.csv"`,
+      },
+    });
+  } catch (error) {
+    return handleAuthError(error);
+  }
+}

--- a/src/components/admin/ReviewRoundPanel.tsx
+++ b/src/components/admin/ReviewRoundPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import Image from "next/image";
 import { MediaTypeBadge } from "../ui/MediaTypeBadge";
 import { VoteTallyBar } from "../community/VoteTallyBar";
 import { REVIEW_SORT_LABELS } from "@/lib/constants";
@@ -12,6 +13,7 @@ export interface RoundCandidate {
   title: string;
   mediaType: "movie" | "tv";
   status: MediaStatus;
+  posterPath: string | null;
   requestedByUsername: string;
   seasonCount: number | null;
   availableSeasonCount: number | null;
@@ -51,13 +53,16 @@ interface ActiveRound {
 interface ReviewRoundPanelProps {
   round: ActiveRound;
   onClosed: () => void;
+  onUpdated?: (round: ActiveRound) => void;
 }
 
-export function ReviewRoundPanel({ round, onClosed }: ReviewRoundPanelProps) {
+export function ReviewRoundPanel({ round, onClosed, onUpdated }: ReviewRoundPanelProps) {
   const [candidates, setCandidates] = useState<RoundCandidate[]>([]);
   const [loading, setLoading] = useState(true);
   const [closing, setClosing] = useState(false);
   const [sort, setSort] = useState<ReviewSort>("votes_asc");
+  const [editingName, setEditingName] = useState(false);
+  const [editName, setEditName] = useState(round.name);
 
   const fetchCandidates = useCallback(async () => {
     setLoading(true);
@@ -95,6 +100,34 @@ export function ReviewRoundPanel({ round, onClosed }: ReviewRoundPanelProps) {
 
   const sortedCandidates = useMemo(() => sortCandidates(candidates, sort), [candidates, sort]);
 
+  const handleUpdate = async (fields: { name?: string; endDate?: string | null }) => {
+    try {
+      const res = await fetch(`/api/admin/review-rounds/${round.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(fields),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        onUpdated?.(data.round);
+      }
+    } catch (error) {
+      console.error("Failed to update review round:", error);
+    }
+  };
+
+  const handleNameSave = () => {
+    const trimmed = editName.trim();
+    if (trimmed && trimmed !== round.name) {
+      handleUpdate({ name: trimmed });
+    }
+    setEditingName(false);
+  };
+
+  const handleEndDateChange = (value: string) => {
+    handleUpdate({ endDate: value || null });
+  };
+
   const handleClose = async () => {
     setClosing(true);
     try {
@@ -115,19 +148,66 @@ export function ReviewRoundPanel({ round, onClosed }: ReviewRoundPanelProps) {
     <div className="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <div className="mb-4 flex items-center justify-between">
         <div>
-          <h3 className="text-lg font-semibold">{round.name}</h3>
-          <p className="text-sm text-gray-400">
-            Started {new Date(round.startedAt).toLocaleDateString()}
-            {round.endDate && ` · Ends ${new Date(round.endDate).toLocaleDateString()}`}
-          </p>
+          {editingName ? (
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onBlur={handleNameSave}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleNameSave();
+                if (e.key === "Escape") {
+                  setEditName(round.name);
+                  setEditingName(false);
+                }
+              }}
+              className="rounded-md border border-gray-600 bg-gray-800 px-2 py-1 text-lg font-semibold text-gray-200"
+              maxLength={100}
+              autoFocus
+            />
+          ) : (
+            <h3
+              className="cursor-pointer text-lg font-semibold hover:text-[#e5a00d]"
+              onClick={() => {
+                setEditName(round.name);
+                setEditingName(true);
+              }}
+              title="Click to edit name"
+            >
+              {round.name}
+            </h3>
+          )}
+          <div className="flex items-center gap-2 text-sm text-gray-400">
+            <span>Started {new Date(round.startedAt).toLocaleDateString()}</span>
+            <span>·</span>
+            <label className="flex items-center gap-1">
+              Ends
+              <input
+                type="date"
+                value={round.endDate ?? ""}
+                onChange={(e) => handleEndDateChange(e.target.value)}
+                min={new Date().toISOString().split("T")[0]}
+                className="rounded border border-gray-700 bg-gray-800 px-1.5 py-0.5 text-sm text-gray-200"
+              />
+            </label>
+          </div>
         </div>
-        <button
-          onClick={handleClose}
-          disabled={closing}
-          className="rounded-md bg-gray-700 px-4 py-2 text-sm font-medium text-gray-200 hover:bg-gray-600 disabled:opacity-50"
-        >
-          {closing ? "Closing..." : "Close Round"}
-        </button>
+        <div className="flex gap-2">
+          <a
+            href={`/api/admin/review-rounds/${round.id}/export`}
+            download
+            className="rounded-md bg-gray-700 px-4 py-2 text-sm font-medium text-gray-200 hover:bg-gray-600"
+          >
+            Export CSV
+          </a>
+          <button
+            onClick={handleClose}
+            disabled={closing}
+            className="rounded-md bg-gray-700 px-4 py-2 text-sm font-medium text-gray-200 hover:bg-gray-600 disabled:opacity-50"
+          >
+            {closing ? "Closing..." : "Close Round"}
+          </button>
+        </div>
       </div>
 
       {!loading && candidates.length > 0 && (
@@ -166,6 +246,28 @@ export function ReviewRoundPanel({ round, onClosed }: ReviewRoundPanelProps) {
               key={c.id}
               className="flex items-center gap-4 rounded-lg border border-gray-800 bg-gray-800/50 p-4"
             >
+              <div className="relative h-16 w-11 flex-shrink-0 overflow-hidden rounded bg-gray-700">
+                {c.posterPath ? (
+                  <Image
+                    src={`https://image.tmdb.org/t/p/w92${c.posterPath}`}
+                    alt={c.title}
+                    fill
+                    className="object-cover"
+                    sizes="44px"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-gray-500">
+                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1}
+                        d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
+                      />
+                    </svg>
+                  </div>
+                )}
+              </div>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <span className="truncate font-medium">{c.title}</span>
@@ -188,7 +290,7 @@ export function ReviewRoundPanel({ round, onClosed }: ReviewRoundPanelProps) {
                     Removed from library
                   </div>
                 ) : (
-                  <div className="mt-2 max-w-xs">
+                  <div className="mt-2 text-left">
                     <VoteTallyBar keepCount={c.tally.keepCount} />
                   </div>
                 )}

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -71,6 +71,29 @@ export const reviewRoundCreateSchema = z.object({
     ),
 });
 
+export const reviewRoundUpdateSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    endDate: z
+      .string()
+      .nullable()
+      .optional()
+      .refine(
+        (val) => {
+          if (val === null || val === undefined) return true;
+          const d = new Date(val);
+          if (isNaN(d.getTime())) return false;
+          const today = new Date();
+          today.setHours(0, 0, 0, 0);
+          return d >= today;
+        },
+        { message: "endDate must be a valid date that is not in the past" }
+      ),
+  })
+  .refine((data) => data.name !== undefined || data.endDate !== undefined, {
+    message: "At least one field (name or endDate) must be provided",
+  });
+
 export const reviewActionSchema = z.object({
   mediaItemId: z.coerce.number().int().positive(),
   action: z.enum(["remove", "keep", "skip"]),
@@ -90,5 +113,6 @@ export type CommunityVoteInput = z.infer<typeof communityVoteSchema>;
 export type CommunityQuery = z.infer<typeof communityQuerySchema>;
 export type AdminUserRequestsQuery = z.infer<typeof adminUserRequestsQuerySchema>;
 export type ReviewRoundCreate = z.infer<typeof reviewRoundCreateSchema>;
+export type ReviewRoundUpdate = z.infer<typeof reviewRoundUpdateSchema>;
 export type ReviewActionInput = z.infer<typeof reviewActionSchema>;
 export type SyncScheduleInput = z.infer<typeof syncScheduleSchema>;


### PR DESCRIPTION
## Summary
- **PATCH endpoint** for review rounds: rename and/or change end date (with Zod validation, null to clear end date)
- **CSV export** endpoint for review round candidates with full tally and action data
- **Inline editing** on active rounds (click name to rename, date picker for end date)
- **Inline editing** on closed rounds (Edit button per row with name + date fields)
- **Poster thumbnails** on review candidate cards (small TMDB images with film-strip fallback)
- **Fix** vote tally text alignment in review panel (was center-aligned, now left-aligned)
- **Refactor** candidate query into shared `getCandidatesForRound()` helper in `lib/db/queries.ts`

## Test plan
- [x] 9 new PATCH tests (name only, endDate only, both, clear endDate, empty body, empty name, 404, 400, 403)
- [x] All 343 tests pass (`npm test`)
- [x] `bun run build` clean — no TypeScript errors
- [ ] Manual: edit active round name/date, edit closed round name/date, verify changes persist on refresh
- [ ] Manual: verify poster thumbnails render on candidate cards
- [ ] Manual: verify CSV export still works for active and closed rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)