### PR TITLE
feat: show nominator on review round candidate cards

### DIFF
--- a/src/app/api/admin/review-rounds/[id]/route.ts
+++ b/src/app/api/admin/review-rounds/[id]/route.ts
@@ -33,6 +33,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
         status: c.status,
         posterPath: c.posterPath || null,
         requestedByUsername: c.requestedByUsername || "Unknown",
+        nominatedBy: c.nominatedByUsernames ? c.nominatedByUsernames.split(",") : [],
         seasonCount: c.seasonCount || null,
         availableSeasonCount: c.availableSeasonCount || null,
         nominationType: (c.nominationType === "trim" ? "trim" : "delete") as "delete" | "trim",

--- a/src/components/admin/ReviewRoundPanel.tsx
+++ b/src/components/admin/ReviewRoundPanel.tsx
@@ -15,6 +15,7 @@ export interface RoundCandidate {
   status: MediaStatus;
   posterPath: string | null;
   requestedByUsername: string;
+  nominatedBy: string[];
   seasonCount: number | null;
   availableSeasonCount: number | null;
   nominationType: "delete" | "trim";
@@ -273,7 +274,15 @@ export function ReviewRoundPanel({ round, onClosed, onUpdated }: ReviewRoundPane
                   <span className="truncate font-medium">{c.title}</span>
                   <MediaTypeBadge mediaType={c.mediaType} />
                 </div>
-                <p className="text-sm text-gray-400">by {c.requestedByUsername}</p>
+                <p className="text-xs text-gray-400">
+                  <span className="text-gray-500">Requested by</span> {c.requestedByUsername}
+                  {c.nominatedBy.length > 0 && (
+                    <>
+                      <span className="mx-1.5 text-gray-600">·</span>
+                      <span className="text-gray-500">Nominated by</span> {c.nominatedBy.join(", ")}
+                    </>
+                  )}
+                </p>
                 {c.nominationType === "trim" && c.keepSeasons && c.seasonCount ? (
                   <p className="text-xs text-amber-400">
                     Trim to latest {c.keepSeasons} of {c.seasonCount} seasons


### PR DESCRIPTION
## Summary
- Add `nominatedBy` field to review round candidate query and API response
- Review candidate cards now clearly label **Requested by** and **Nominated by** as distinct roles
- Makes it easy for admins to see who originally requested content vs who flagged it for deletion

## Test plan
- [x] All 343 tests pass (`npm test`)
- [x] `bun run build` clean
- [ ] Manual: verify candidate cards show correct requester and nominator names
- [ ] Manual: verify self-nominations show the same user for both labels
- [ ] Manual: verify admin nominations show admin username as nominator

🤖 Generated with [Claude Code](https://claude.com/claude-code)