### PR TITLE
chore: add publish step for automatic GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
           version: npx changeset version
+          publish: npx changeset tag
           commit: "chore: version packages"
           title: "chore: version packages"
         env:


### PR DESCRIPTION
## Summary

- Add `publish: npx changeset tag` to the Changesets action
- When the "Version Packages" PR is merged, the action now automatically creates git tags and GitHub releases — no manual `gh release create` needed

No changeset needed (CI config only).

## Test plan

- [ ] Merge this PR, then merge a future PR with a changeset
- [ ] Verify the Version Packages PR is created
- [ ] Merge the Version Packages PR and confirm a GitHub release is auto-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)