### PR TITLE
refactor: extract shared BaseMediaCard component

### DIFF
--- a/.changeset/dry-base-media-card.md
+++ b/.changeset/dry-base-media-card.md
@@ -1,0 +1,5 @@
+---
+"shelflife": minor
+---
+
+Extract shared BaseMediaCard component to DRY up MediaCard, CommunityCard, and AdminUserMedia card rendering

--- a/src/components/admin/AdminUserMedia.tsx
+++ b/src/components/admin/AdminUserMedia.tsx
@@ -3,13 +3,10 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Pagination } from "../ui/Pagination";
-import { MediaTypeBadge } from "../ui/MediaTypeBadge";
-import { ExternalLinks } from "../ui/ExternalLinks";
-import { ClickablePoster } from "../ui/ClickablePoster";
-import { MediaDetailModal } from "../ui/MediaDetailModal";
 import { MediaCardSkeleton } from "../ui/MediaCardSkeleton";
+import { BaseMediaCard } from "../ui/BaseMediaCard";
 import { VoteButton } from "../media/VoteButton";
-import { STATUS_COLORS, VOTE_COLORS, VOTE_LABELS } from "@/lib/constants";
+import { VOTE_COLORS, VOTE_LABELS } from "@/lib/constants";
 import type { MediaItemWithVote, VoteValue } from "@/types";
 
 interface AdminUserMediaProps {
@@ -26,7 +23,6 @@ export function AdminUserMedia({ plexId, statsFilter }: AdminUserMediaProps) {
   const [totalPages, setTotalPages] = useState(1);
   const [totalItems, setTotalItems] = useState(0);
   const [filter, setFilter] = useState("all");
-  const [detailId, setDetailId] = useState<number | null>(null);
 
   // Reset page when statsFilter changes
   useEffect(() => {
@@ -114,94 +110,49 @@ export function AdminUserMedia({ plexId, statsFilter }: AdminUserMediaProps) {
       ) : (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
           {filtered.map((item) => (
-            <div
+            <BaseMediaCard
               key={item.id}
-              className="overflow-hidden rounded-lg border border-gray-800 bg-gray-900"
+              title={item.title}
+              mediaType={item.mediaType}
+              posterPath={item.posterPath}
+              status={item.status}
+              tmdbId={item.tmdbId}
+              tvdbId={item.tvdbId}
+              imdbId={item.imdbId}
+              overseerrId={item.overseerrId}
+              seasonCount={item.seasonCount}
+              availableSeasonCount={item.availableSeasonCount}
+              watchStatus={item.watchStatus}
+              fileSize={item.fileSize}
             >
-              <ClickablePoster
-                posterPath={item.posterPath}
-                title={item.title}
-                onClick={() => setDetailId(item.id)}
-              >
-                <div className="absolute top-2 left-2 flex gap-1">
-                  <MediaTypeBadge mediaType={item.mediaType} />
-                </div>
-                {item.watchStatus?.watched && (
-                  <div className="absolute top-2 right-2">
-                    <span className="rounded bg-purple-900/80 px-2 py-0.5 text-xs text-purple-300">
-                      Watched
-                    </span>
-                  </div>
-                )}
-              </ClickablePoster>
-              <div className="space-y-2 p-3">
-                <h3 className="truncate text-sm font-medium" title={item.title}>
-                  {item.title}
-                </h3>
-                <div className="flex items-center gap-2">
-                  <span
-                    className={`rounded px-2 py-0.5 text-xs ${STATUS_COLORS[item.status] || STATUS_COLORS.unknown}`}
-                  >
-                    {item.status}
-                  </span>
-                  {item.vote ? (
-                    <span
-                      className={`rounded px-2 py-0.5 text-xs ${VOTE_COLORS[item.vote] || "bg-red-900/50 text-red-300"}`}
-                    >
-                      User: {VOTE_LABELS[item.vote] || "Nominated"}
-                    </span>
-                  ) : (
-                    <span className="rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-500">
-                      User: Not nominated
-                    </span>
-                  )}
-                </div>
-                <div className="mt-1">
-                  <p className="mb-1 text-xs text-gray-500">Your nomination:</p>
-                  <VoteButton
-                    mediaItemId={item.id}
-                    currentVote={item.adminVote ?? null}
-                    seasonCount={item.seasonCount}
-                    mediaType={item.mediaType}
-                    currentKeepSeasons={item.adminKeepSeasons ?? null}
-                    onVoteChange={(newVote: VoteValue | null) => {
-                      setItems((prev) =>
-                        prev.map((i) => (i.id === item.id ? { ...i, adminVote: newVote } : i))
-                      );
-                      router.refresh();
-                    }}
-                  />
-                </div>
-                {item.watchStatus && item.watchStatus.playCount > 0 && (
-                  <p className="text-xs text-gray-500">
-                    {item.watchStatus.playCount} play
-                    {item.watchStatus.playCount !== 1 ? "s" : ""}
-                  </p>
-                )}
-                <ExternalLinks
-                  imdbId={item.imdbId}
-                  tmdbId={item.tmdbId}
+              {item.vote ? (
+                <span
+                  className={`rounded px-2 py-0.5 text-xs ${VOTE_COLORS[item.vote] || "bg-red-900/50 text-red-300"}`}
+                >
+                  User: {VOTE_LABELS[item.vote] || "Nominated"}
+                </span>
+              ) : (
+                <span className="rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-500">
+                  User: Not nominated
+                </span>
+              )}
+              <div className="mt-1">
+                <p className="mb-1 text-xs text-gray-500">Your nomination:</p>
+                <VoteButton
+                  mediaItemId={item.id}
+                  currentVote={item.adminVote ?? null}
+                  seasonCount={item.seasonCount}
                   mediaType={item.mediaType}
+                  currentKeepSeasons={item.adminKeepSeasons ?? null}
+                  onVoteChange={(newVote: VoteValue | null) => {
+                    setItems((prev) =>
+                      prev.map((i) => (i.id === item.id ? { ...i, adminVote: newVote } : i))
+                    );
+                    router.refresh();
+                  }}
                 />
               </div>
-              {detailId === item.id && (
-                <MediaDetailModal
-                  title={item.title}
-                  mediaType={item.mediaType}
-                  status={item.status}
-                  posterPath={item.posterPath}
-                  seasonCount={item.seasonCount}
-                  availableSeasonCount={item.availableSeasonCount}
-                  playCount={item.watchStatus?.playCount}
-                  fileSize={item.fileSize}
-                  tmdbId={item.tmdbId}
-                  tvdbId={item.tvdbId}
-                  imdbId={item.imdbId}
-                  overseerrId={item.overseerrId}
-                  onClose={() => setDetailId(null)}
-                />
-              )}
-            </div>
+            </BaseMediaCard>
           ))}
         </div>
       )}

--- a/src/components/community/CommunityCard.tsx
+++ b/src/components/community/CommunityCard.tsx
@@ -1,15 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { MediaTypeBadge } from "../ui/MediaTypeBadge";
-import { ExternalLinks } from "../ui/ExternalLinks";
-import { ClickablePoster } from "../ui/ClickablePoster";
-import { MediaDetailModal } from "../ui/MediaDetailModal";
 import { VoteTallyBar } from "./VoteTallyBar";
 import { CommunityVoteButton } from "./CommunityVoteButton";
 import { VoteButton } from "../media/VoteButton";
-import { STATUS_COLORS } from "@/lib/constants";
-import { formatFileSize } from "@/lib/format";
+import { BaseMediaCard } from "../ui/BaseMediaCard";
 import type { CommunityCandidate, CommunityVoteValue, VoteValue } from "@/types";
 
 interface CommunityCardProps {
@@ -19,117 +13,61 @@ interface CommunityCardProps {
 }
 
 export function CommunityCard({ item, onVoteChange, onSelfVoteChange }: CommunityCardProps) {
-  const [showDetail, setShowDetail] = useState(false);
-
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-900">
-      <ClickablePoster
-        posterPath={item.posterPath}
-        title={item.title}
-        onClick={() => setShowDetail(true)}
-      >
-        <div className="absolute top-2 left-2 flex gap-1">
-          <MediaTypeBadge mediaType={item.mediaType} />
-          <span
-            className={`rounded px-2 py-0.5 text-xs ${STATUS_COLORS[item.status] || STATUS_COLORS.unknown}`}
-          >
-            {item.status}
-          </span>
+    <BaseMediaCard
+      title={item.title}
+      mediaType={item.mediaType}
+      posterPath={item.posterPath}
+      status={item.status}
+      tmdbId={item.tmdbId}
+      tvdbId={item.tvdbId}
+      imdbId={item.imdbId}
+      overseerrId={item.overseerrId}
+      seasonCount={item.seasonCount}
+      availableSeasonCount={item.availableSeasonCount}
+      keepSeasons={item.nominationType === "trim" ? item.keepSeasons : null}
+      watchStatus={item.watchStatus}
+      fileSize={item.fileSize}
+      requestedByUsername={item.requestedByUsername}
+      showLastWatched
+    >
+      {item.status === "removed" ? (
+        <div className="rounded bg-red-900/30 px-2 py-2 text-center text-sm font-medium text-red-400">
+          Removed from library
         </div>
-        {item.watchStatus?.watched && (
-          <div className="absolute top-2 right-2">
-            <span className="rounded bg-purple-900/80 px-2 py-0.5 text-xs text-purple-300">
-              Watched
-            </span>
-          </div>
-        )}
-      </ClickablePoster>
-      <div className="space-y-2 p-3">
-        <h3 className="truncate text-sm font-medium" title={item.title}>
-          {item.title}
-        </h3>
-        {item.nominationType === "trim" && item.keepSeasons && item.seasonCount ? (
-          <p className="text-xs text-amber-400">
-            Trim: keep latest {item.keepSeasons} of {item.seasonCount} seasons
-          </p>
-        ) : item.seasonCount && item.seasonCount > 1 ? (
-          <p className="text-xs text-gray-500">
-            {item.availableSeasonCount && item.availableSeasonCount !== item.seasonCount
-              ? `${item.availableSeasonCount} of ${item.seasonCount} seasons`
-              : `${item.seasonCount} seasons`}
-          </p>
-        ) : null}
-        <p className="text-xs text-gray-400">Requested by: {item.requestedByUsername}</p>
-        {item.watchStatus || item.fileSize ? (
-          <div className="flex items-center gap-3 text-xs text-gray-500">
-            {item.watchStatus && (
-              <span>
-                Plays: {item.watchStatus.playCount}
-                {item.watchStatus.lastWatchedAt && (
-                  <> | Last: {new Date(item.watchStatus.lastWatchedAt).toLocaleDateString()}</>
-                )}
-              </span>
-            )}
-            {item.fileSize ? <span>{formatFileSize(item.fileSize)}</span> : null}
-          </div>
-        ) : null}
-        <ExternalLinks imdbId={item.imdbId} tmdbId={item.tmdbId} mediaType={item.mediaType} />
-        {item.status === "removed" ? (
-          <div className="rounded bg-red-900/30 px-2 py-2 text-center text-sm font-medium text-red-400">
-            Removed from library
-          </div>
-        ) : (
-          <>
-            <VoteTallyBar keepCount={item.tally.keepCount} />
-            {item.isNominator ? (
-              <div className="space-y-1">
-                <p className="text-xs text-gray-500">Your nomination — change your vote:</p>
-                <VoteButton
-                  mediaItemId={item.id}
-                  currentVote={item.nominationType}
-                  seasonCount={item.seasonCount}
-                  mediaType={item.mediaType}
-                  currentKeepSeasons={item.keepSeasons}
-                  onVoteChange={(newVote: VoteValue | null) => onSelfVoteChange?.(item.id, newVote)}
-                />
-              </div>
-            ) : item.isRequestor ? (
-              <div className="space-y-1">
-                <p className="text-xs text-amber-400">Admin nomination</p>
-                <CommunityVoteButton
-                  mediaItemId={item.id}
-                  currentVote={item.currentUserVote}
-                  onVoteChange={(vote, delta) => onVoteChange?.(item.id, vote, delta)}
-                />
-              </div>
-            ) : (
+      ) : (
+        <>
+          <VoteTallyBar keepCount={item.tally.keepCount} />
+          {item.isNominator ? (
+            <div className="space-y-1">
+              <p className="text-xs text-gray-500">Your nomination — change your vote:</p>
+              <VoteButton
+                mediaItemId={item.id}
+                currentVote={item.nominationType}
+                seasonCount={item.seasonCount}
+                mediaType={item.mediaType}
+                currentKeepSeasons={item.keepSeasons}
+                onVoteChange={(newVote: VoteValue | null) => onSelfVoteChange?.(item.id, newVote)}
+              />
+            </div>
+          ) : item.isRequestor ? (
+            <div className="space-y-1">
+              <p className="text-xs text-amber-400">Admin nomination</p>
               <CommunityVoteButton
                 mediaItemId={item.id}
                 currentVote={item.currentUserVote}
                 onVoteChange={(vote, delta) => onVoteChange?.(item.id, vote, delta)}
               />
-            )}
-          </>
-        )}
-      </div>
-      {showDetail && (
-        <MediaDetailModal
-          title={item.title}
-          mediaType={item.mediaType}
-          status={item.status}
-          posterPath={item.posterPath}
-          seasonCount={item.seasonCount}
-          availableSeasonCount={item.availableSeasonCount}
-          requestedByUsername={item.requestedByUsername}
-          playCount={item.watchStatus?.playCount}
-          fileSize={item.fileSize}
-          tmdbId={item.tmdbId}
-          tvdbId={item.tvdbId}
-          imdbId={item.imdbId}
-          overseerrId={item.overseerrId}
-          onClose={() => setShowDetail(false)}
-        />
+            </div>
+          ) : (
+            <CommunityVoteButton
+              mediaItemId={item.id}
+              currentVote={item.currentUserVote}
+              onVoteChange={(vote, delta) => onVoteChange?.(item.id, vote, delta)}
+            />
+          )}
+        </>
       )}
-    </div>
+    </BaseMediaCard>
   );
 }

--- a/src/components/media/MediaCard.tsx
+++ b/src/components/media/MediaCard.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { VoteButton } from "./VoteButton";
-import { MediaTypeBadge } from "../ui/MediaTypeBadge";
-import { ExternalLinks } from "../ui/ExternalLinks";
-import { ClickablePoster } from "../ui/ClickablePoster";
-import { MediaDetailModal } from "../ui/MediaDetailModal";
-import { STATUS_COLORS } from "@/lib/constants";
-import { formatFileSize } from "@/lib/format";
+import { BaseMediaCard } from "../ui/BaseMediaCard";
 import type { MediaItemWithVote, VoteValue } from "@/types";
 
 interface MediaCardProps {
@@ -16,87 +10,32 @@ interface MediaCardProps {
 }
 
 export function MediaCard({ item, onVoteChange }: MediaCardProps) {
-  const [showDetail, setShowDetail] = useState(false);
-
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-900">
-      <ClickablePoster
-        posterPath={item.posterPath}
-        title={item.title}
-        onClick={() => setShowDetail(true)}
-      >
-        <div className="absolute top-2 left-2 flex gap-1">
-          <MediaTypeBadge mediaType={item.mediaType} />
-          <span
-            className={`rounded px-2 py-0.5 text-xs ${STATUS_COLORS[item.status] || STATUS_COLORS.unknown}`}
-          >
-            {item.status}
-          </span>
-        </div>
-        {item.watchStatus?.watched && (
-          <div className="absolute top-2 right-2">
-            <span className="rounded bg-purple-900/80 px-2 py-0.5 text-xs text-purple-300">
-              Watched
-            </span>
-          </div>
-        )}
-      </ClickablePoster>
-      <div className="space-y-3 p-3">
-        <h3 className="truncate text-sm font-medium" title={item.title}>
-          {item.title}
-        </h3>
-        {item.mediaType === "tv" && item.seasonCount && item.seasonCount > 1 && (
-          <p className="text-xs text-gray-500">
-            {item.availableSeasonCount && item.availableSeasonCount !== item.seasonCount
-              ? `${item.availableSeasonCount} of ${item.seasonCount} seasons`
-              : `${item.seasonCount} seasons`}
-          </p>
-        )}
-        {item.vote === "trim" && item.keepSeasons && item.seasonCount && (
-          <p className="text-xs text-amber-400">
-            Keeping latest {item.keepSeasons} of {item.seasonCount} seasons
-          </p>
-        )}
-        {item.watchStatus?.playCount || item.fileSize ? (
-          <div className="flex items-center gap-3 text-xs text-gray-500">
-            {item.watchStatus && item.watchStatus.playCount > 0 && (
-              <span>
-                Played {item.watchStatus.playCount} time
-                {item.watchStatus.playCount !== 1 ? "s" : ""}
-              </span>
-            )}
-            {item.fileSize ? <span>{formatFileSize(item.fileSize)}</span> : null}
-          </div>
-        ) : null}
-        <ExternalLinks imdbId={item.imdbId} tmdbId={item.tmdbId} mediaType={item.mediaType} />
-        <VoteButton
-          mediaItemId={item.id}
-          currentVote={item.vote}
-          seasonCount={item.seasonCount}
-          mediaType={item.mediaType}
-          currentKeepSeasons={item.keepSeasons}
-          onVoteChange={(newVote: VoteValue | null, oldVote: VoteValue | null) =>
-            onVoteChange?.(item.id, oldVote, newVote)
-          }
-        />
-      </div>
-      {showDetail && (
-        <MediaDetailModal
-          title={item.title}
-          mediaType={item.mediaType}
-          status={item.status}
-          posterPath={item.posterPath}
-          seasonCount={item.seasonCount}
-          availableSeasonCount={item.availableSeasonCount}
-          playCount={item.watchStatus?.playCount}
-          fileSize={item.fileSize}
-          tmdbId={item.tmdbId}
-          tvdbId={item.tvdbId}
-          imdbId={item.imdbId}
-          overseerrId={item.overseerrId}
-          onClose={() => setShowDetail(false)}
-        />
-      )}
-    </div>
+    <BaseMediaCard
+      title={item.title}
+      mediaType={item.mediaType}
+      posterPath={item.posterPath}
+      status={item.status}
+      tmdbId={item.tmdbId}
+      tvdbId={item.tvdbId}
+      imdbId={item.imdbId}
+      overseerrId={item.overseerrId}
+      seasonCount={item.seasonCount}
+      availableSeasonCount={item.availableSeasonCount}
+      keepSeasons={item.vote === "trim" ? item.keepSeasons : null}
+      watchStatus={item.watchStatus}
+      fileSize={item.fileSize}
+    >
+      <VoteButton
+        mediaItemId={item.id}
+        currentVote={item.vote}
+        seasonCount={item.seasonCount}
+        mediaType={item.mediaType}
+        currentKeepSeasons={item.keepSeasons}
+        onVoteChange={(newVote: VoteValue | null, oldVote: VoteValue | null) =>
+          onVoteChange?.(item.id, oldVote, newVote)
+        }
+      />
+    </BaseMediaCard>
   );
 }

--- a/src/components/ui/BaseMediaCard.tsx
+++ b/src/components/ui/BaseMediaCard.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { MediaTypeBadge } from "./MediaTypeBadge";
+import { ExternalLinks } from "./ExternalLinks";
+import { ClickablePoster } from "./ClickablePoster";
+import { MediaDetailModal } from "./MediaDetailModal";
+import { STATUS_COLORS } from "@/lib/constants";
+import { formatFileSize } from "@/lib/format";
+import type { MediaStatus, MediaType, WatchStatusSummary } from "@/types";
+
+interface BaseMediaCardProps {
+  title: string;
+  mediaType: MediaType;
+  posterPath: string | null;
+  status: MediaStatus;
+
+  tmdbId: number | null;
+  tvdbId: number | null;
+  imdbId: string | null;
+  overseerrId: number | null;
+
+  seasonCount: number | null;
+  availableSeasonCount: number | null;
+
+  keepSeasons?: number | null;
+
+  watchStatus?: WatchStatusSummary | null;
+
+  fileSize?: number | null;
+
+  requestedByUsername?: string;
+
+  showLastWatched?: boolean;
+
+  children?: ReactNode;
+}
+
+export function BaseMediaCard({
+  title,
+  mediaType,
+  posterPath,
+  status,
+  tmdbId,
+  tvdbId,
+  imdbId,
+  overseerrId,
+  seasonCount,
+  availableSeasonCount,
+  keepSeasons,
+  watchStatus,
+  fileSize,
+  requestedByUsername,
+  showLastWatched,
+  children,
+}: BaseMediaCardProps) {
+  const [showDetail, setShowDetail] = useState(false);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-900">
+      <ClickablePoster posterPath={posterPath} title={title} onClick={() => setShowDetail(true)}>
+        <div className="absolute top-2 left-2 flex gap-1">
+          <MediaTypeBadge mediaType={mediaType} />
+          <span
+            className={`rounded px-2 py-0.5 text-xs ${STATUS_COLORS[status] || STATUS_COLORS.unknown}`}
+          >
+            {status}
+          </span>
+        </div>
+        {watchStatus?.watched && (
+          <div className="absolute top-2 right-2">
+            <span className="rounded bg-purple-900/80 px-2 py-0.5 text-xs text-purple-300">
+              Watched
+            </span>
+          </div>
+        )}
+      </ClickablePoster>
+      <div className="space-y-2 p-3">
+        <h3 className="truncate text-sm font-medium" title={title}>
+          {title}
+        </h3>
+        {keepSeasons != null && keepSeasons > 0 && seasonCount ? (
+          <p className="text-xs text-amber-400">
+            Keeping latest {keepSeasons} of {seasonCount} seasons
+          </p>
+        ) : mediaType === "tv" && seasonCount && seasonCount > 1 ? (
+          <p className="text-xs text-gray-500">
+            {availableSeasonCount && availableSeasonCount !== seasonCount
+              ? `${availableSeasonCount} of ${seasonCount} seasons`
+              : `${seasonCount} seasons`}
+          </p>
+        ) : null}
+        {requestedByUsername && (
+          <p className="text-xs text-gray-400">Requested by: {requestedByUsername}</p>
+        )}
+        {watchStatus?.playCount || fileSize ? (
+          <div className="flex items-center gap-3 text-xs text-gray-500">
+            {watchStatus && watchStatus.playCount > 0 && (
+              <span>
+                Plays: {watchStatus.playCount}
+                {showLastWatched && watchStatus.lastWatchedAt && (
+                  <> | Last: {new Date(watchStatus.lastWatchedAt).toLocaleDateString()}</>
+                )}
+              </span>
+            )}
+            {fileSize ? <span>{formatFileSize(fileSize)}</span> : null}
+          </div>
+        ) : null}
+        <ExternalLinks imdbId={imdbId} tmdbId={tmdbId} mediaType={mediaType} />
+        {children}
+      </div>
+      {showDetail && (
+        <MediaDetailModal
+          title={title}
+          mediaType={mediaType}
+          status={status}
+          posterPath={posterPath}
+          seasonCount={seasonCount}
+          availableSeasonCount={availableSeasonCount}
+          requestedByUsername={requestedByUsername}
+          playCount={watchStatus?.playCount}
+          fileSize={fileSize}
+          tmdbId={tmdbId}
+          tvdbId={tvdbId}
+          imdbId={imdbId}
+          overseerrId={overseerrId}
+          onClose={() => setShowDetail(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/MediaCardSkeleton.tsx
+++ b/src/components/ui/MediaCardSkeleton.tsx
@@ -11,7 +11,7 @@ export function MediaCardSkeleton({ count = 10 }: MediaCardSkeletonProps) {
           className="animate-pulse overflow-hidden rounded-lg border border-gray-800 bg-gray-900"
         >
           <div className="aspect-[2/3] bg-gray-800" />
-          <div className="space-y-3 p-3">
+          <div className="space-y-2 p-3">
             <div className="h-4 rounded bg-gray-800" />
             <div className="h-8 rounded bg-gray-800" />
           </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,16 +74,18 @@ export interface SessionPayload {
   isAdmin: boolean;
 }
 
+export interface WatchStatusSummary {
+  watched: boolean;
+  playCount: number;
+  lastWatchedAt: string | null;
+}
+
 export interface MediaItemWithVote extends MediaItem {
   vote: VoteValue | null;
   keepSeasons: number | null;
   adminVote?: VoteValue | null;
   adminKeepSeasons?: number | null;
-  watchStatus: {
-    watched: boolean;
-    playCount: number;
-    lastWatchedAt: string | null;
-  } | null;
+  watchStatus: WatchStatusSummary | null;
 }
 
 export interface ReviewCompletionSummary {
@@ -116,11 +118,7 @@ export interface CommunityCandidate {
   fileSize: number | null;
   nominationType: "delete" | "trim";
   keepSeasons: number | null;
-  watchStatus: {
-    watched: boolean;
-    playCount: number;
-    lastWatchedAt: string | null;
-  } | null;
+  watchStatus: WatchStatusSummary | null;
   tally: { keepCount: number };
   currentUserVote: CommunityVoteValue | null;
   isRequestor: boolean;


### PR DESCRIPTION
## Summary

- Extracts shared `BaseMediaCard` component from `MediaCard`, `CommunityCard`, and `AdminUserMedia`, eliminating ~170 lines of duplicated poster/badge/title/season/modal rendering
- Each consumer now passes only its unique footer content (vote buttons, tallies, admin controls) via a `children` slot
- Extracts `WatchStatusSummary` shared type to prevent inline type drift across components

## Intentional behavior unifications

| Change | Before | After |
|--------|--------|-------|
| AdminUserMedia status badge | Rendered in card body | Poster overlay (consistent with other views) |
| AdminUserMedia season info + file size | Only in modal | Now visible in card body |
| CommunityCard trim wording | "Trim: keep latest X of Y" | "Keeping latest X of Y" |
| MediaCard play count format | "Played X time(s)" | "Plays: X" |
| AdminUserMedia play count format | "X play(s)" | "Plays: X" |
| Skeleton spacing | `space-y-3` | `space-y-2` (matches real card) |

CommunityCard retains its "Last watched" date display via opt-in `showLastWatched` prop.

## Test plan

- [x] `npm test` — all 414 tests pass
- [x] `bun run build` — clean production build
- [ ] Manual: verify Dashboard cards render correctly
- [ ] Manual: verify Community cards render correctly (including last-watched date)
- [ ] Manual: verify Admin User Media cards render correctly (status badge in overlay, season info + file size visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)