### PR TITLE
feat: add Seerr and Jellyseerr support with auto-detection

### DIFF
--- a/.changeset/seerr-support.md
+++ b/.changeset/seerr-support.md
@@ -1,0 +1,5 @@
+---
+"shelflife": minor
+---
+
+Add Seerr support as the primary request service, with Overseerr and Jellyseerr as legacy fallbacks. Auto-detects the active provider from env vars (Seerr > Overseerr > Jellyseerr) and dynamically reflects the provider name in all UI labels.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,17 @@
-# Overseerr
-OVERSEERR_URL=http://your-unraid-ip:5055
-OVERSEERR_API_KEY=your-overseerr-api-key
+# Seerr (primary — the successor to Overseerr and Jellyseerr)
+SEERR_URL=http://your-unraid-ip:5055
+SEERR_API_KEY=your-seerr-api-key
+NEXT_PUBLIC_SEERR_URL=http://your-unraid-ip:5055
+
+# Overseerr (legacy fallback — used only if Seerr vars are not set)
+# OVERSEERR_URL=http://your-unraid-ip:5055
+# OVERSEERR_API_KEY=your-overseerr-api-key
+# NEXT_PUBLIC_OVERSEERR_URL=http://your-unraid-ip:5055
+
+# Jellyseerr (legacy fallback — used only if Seerr and Overseerr vars are not set)
+# JELLYSEERR_URL=http://your-unraid-ip:5055
+# JELLYSEERR_API_KEY=your-jellyseerr-api-key
+# NEXT_PUBLIC_JELLYSEERR_URL=http://your-unraid-ip:5055
 
 # Tautulli
 TAUTULLI_URL=http://your-unraid-ip:8181

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Shelflife
 
-Manage your Plex library storage. Shelflife connects to [Overseerr](https://overseerr.dev/) and [Tautulli](https://tautulli.com/) to let users vote on whether content they requested should be kept or deleted. Admins get a dashboard showing what can be safely pruned.
+Manage your Plex library storage. Shelflife connects to [Seerr](https://github.com/seerr-app/seerr) (or [Overseerr](https://overseerr.dev/)/[Jellyseerr](https://github.com/Fallenbagel/jellyseerr) for legacy setups) and [Tautulli](https://tautulli.com/) to let users vote on whether content they requested should be kept or deleted. Admins get a dashboard showing what can be safely pruned.
 
 ## How it works
 
-1. Users sign in with their Plex account (same login as Overseerr)
-2. Shelflife syncs media requests from Overseerr and watch history from Tautulli
+1. Users sign in with their Plex account (same login as Seerr/Overseerr)
+2. Shelflife syncs media requests from Seerr (or Overseerr) and watch history from Tautulli
 3. Each user sees their own requests and marks them as **Keep** or **Can Delete**
 4. Admins see an aggregate view of what users have flagged for deletion
 
@@ -13,9 +13,11 @@ By default Shelflife is read-only -- it syncs data but never modifies your exter
 
 ## Requirements
 
-- [Overseerr](https://overseerr.dev/) -- for media request data
+- [Seerr](https://github.com/seerr-app/seerr), [Overseerr](https://overseerr.dev/) (legacy), or [Jellyseerr](https://github.com/Fallenbagel/jellyseerr) (legacy) -- for media request data
 - [Tautulli](https://tautulli.com/) -- for watch history
 - A Plex account
+
+> **Note:** Both Overseerr and Jellyseerr have been archived and succeeded by Seerr (v3.0.0+). Shelflife supports all three -- configure `SEERR_URL`/`SEERR_API_KEY` for Seerr, `OVERSEERR_URL`/`OVERSEERR_API_KEY` for legacy Overseerr, or `JELLYSEERR_URL`/`JELLYSEERR_API_KEY` for legacy Jellyseerr. Seerr takes priority when multiple are configured.
 
 ### Tautulli setup for file size display
 
@@ -33,22 +35,31 @@ After this, Tautulli will return TV show file sizes in its API, and Shelflife wi
 
 ## Configuration
 
-| Variable            | Required | Description                                                                            |
-| ------------------- | -------- | -------------------------------------------------------------------------------------- |
-| `OVERSEERR_URL`     | Yes      | URL of your Overseerr instance (e.g. `http://192.168.1.100:5055`)                      |
-| `OVERSEERR_API_KEY` | Yes      | Found in Overseerr under Settings > General                                            |
-| `TAUTULLI_URL`      | Yes      | URL of your Tautulli instance (e.g. `http://192.168.1.100:8181`)                       |
-| `TAUTULLI_API_KEY`  | Yes      | Found in Tautulli under Settings > Web Interface                                       |
-| `SESSION_SECRET`    | Yes      | Random string for signing sessions (minimum 32 characters)                             |
-| `SONARR_URL`        | No       | URL of your Sonarr instance -- enables TV show deletion from admin                     |
-| `SONARR_API_KEY`    | No       | Found in Sonarr under Settings > General                                               |
-| `RADARR_URL`        | No       | URL of your Radarr instance -- enables movie deletion from admin                       |
-| `RADARR_API_KEY`    | No       | Found in Radarr under Settings > General                                               |
-| `PLEX_CLIENT_ID`    | No       | Identifier for Plex auth (defaults to `shelflife`)                                     |
-| `ADMIN_PLEX_ID`     | No       | Force a specific Plex user as admin. If unset, the first user to sign in becomes admin |
-| `DATABASE_PATH`     | No       | Path to SQLite database (defaults to `/app/data/shelflife.db` in Docker)               |
-| `COOKIE_SECURE`     | No       | Set to `true` if behind HTTPS reverse proxy. Defaults to `false` for plain HTTP        |
-| `DEBUG`             | No       | Set to `true` for verbose debug logging (useful for troubleshooting)                   |
+| Variable                     | Required | Description                                                                            |
+| ---------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `SEERR_URL`                  | \*       | URL of your Seerr instance (e.g. `http://192.168.1.100:5055`)                          |
+| `SEERR_API_KEY`              | \*       | Found in Seerr under Settings > General                                                |
+| `NEXT_PUBLIC_SEERR_URL`      | No       | Public URL of your Seerr instance (for deep links in the UI)                           |
+| `OVERSEERR_URL`              | \*       | URL of your Overseerr instance (legacy fallback)                                       |
+| `OVERSEERR_API_KEY`          | \*       | Found in Overseerr under Settings > General                                            |
+| `NEXT_PUBLIC_OVERSEERR_URL`  | No       | Public URL of your Overseerr instance (legacy fallback for UI links)                   |
+| `JELLYSEERR_URL`             | \*       | URL of your Jellyseerr instance (legacy fallback)                                      |
+| `JELLYSEERR_API_KEY`         | \*       | Found in Jellyseerr under Settings > General                                           |
+| `NEXT_PUBLIC_JELLYSEERR_URL` | No       | Public URL of your Jellyseerr instance (legacy fallback for UI links)                  |
+| `TAUTULLI_URL`               | Yes      | URL of your Tautulli instance (e.g. `http://192.168.1.100:8181`)                       |
+| `TAUTULLI_API_KEY`           | Yes      | Found in Tautulli under Settings > Web Interface                                       |
+| `SESSION_SECRET`             | Yes      | Random string for signing sessions (minimum 32 characters)                             |
+| `SONARR_URL`                 | No       | URL of your Sonarr instance -- enables TV show deletion from admin                     |
+| `SONARR_API_KEY`             | No       | Found in Sonarr under Settings > General                                               |
+| `RADARR_URL`                 | No       | URL of your Radarr instance -- enables movie deletion from admin                       |
+| `RADARR_API_KEY`             | No       | Found in Radarr under Settings > General                                               |
+| `PLEX_CLIENT_ID`             | No       | Identifier for Plex auth (defaults to `shelflife`)                                     |
+| `ADMIN_PLEX_ID`              | No       | Force a specific Plex user as admin. If unset, the first user to sign in becomes admin |
+| `DATABASE_PATH`              | No       | Path to SQLite database (defaults to `/app/data/shelflife.db` in Docker)               |
+| `COOKIE_SECURE`              | No       | Set to `true` if behind HTTPS reverse proxy. Defaults to `false` for plain HTTP        |
+| `DEBUG`                      | No       | Set to `true` for verbose debug logging (useful for troubleshooting)                   |
+
+\* One of `SEERR_URL`/`SEERR_API_KEY`, `OVERSEERR_URL`/`OVERSEERR_API_KEY`, or `JELLYSEERR_URL`/`JELLYSEERR_API_KEY` must be set. When multiple are configured, Seerr takes priority.
 
 ## Running with Docker Compose
 
@@ -61,8 +72,9 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - OVERSEERR_URL=http://your-ip:5055
-      - OVERSEERR_API_KEY=your-key
+      # Seerr (recommended) — or use OVERSEERR_URL/OVERSEERR_API_KEY for legacy
+      - SEERR_URL=http://your-ip:5055
+      - SEERR_API_KEY=your-key
       - TAUTULLI_URL=http://your-ip:8181
       - TAUTULLI_API_KEY=your-key
       - SESSION_SECRET=your-random-32-char-secret
@@ -86,13 +98,13 @@ The app will be available at `http://localhost:3000`.
 
 ## Running on Unraid
 
-> **Important -- Networking:** Shelflife needs to reach your Overseerr and Tautulli instances. On Unraid with the default bridge network, `localhost` and `127.0.0.1` refer to the container itself, not your server. Use your **Unraid server's IP address** (e.g. `http://192.168.1.100:5055`) when setting `OVERSEERR_URL` and `TAUTULLI_URL`.
+> **Important -- Networking:** Shelflife needs to reach your Seerr/Overseerr and Tautulli instances. On Unraid with the default bridge network, `localhost` and `127.0.0.1` refer to the container itself, not your server. Use your **Unraid server's IP address** (e.g. `http://192.168.1.100:5055`) when setting `SEERR_URL` (or `OVERSEERR_URL`) and `TAUTULLI_URL`.
 
 ### Getting your API keys
 
 Before starting, grab these from your existing services:
 
-- **Overseerr API Key**: Open Overseerr > Settings > General > scroll to **API Key** and copy it
+- **Seerr API Key**: Open Seerr > Settings > General > scroll to **API Key** and copy it (or use your existing Overseerr API key if still on Overseerr)
 - **Tautulli API Key**: Open Tautulli > Settings > Web Interface > scroll to **API Key** and copy it
 
 ### Generating a session secret
@@ -122,8 +134,9 @@ Requires the [**Compose Manager**](https://forums.unraid.net/topic/114415-plugin
        ports:
          - "3000:3000"
        environment:
-         - OVERSEERR_URL=http://YOUR_UNRAID_IP:5055
-         - OVERSEERR_API_KEY=your-overseerr-api-key
+         # Seerr (recommended) — or use OVERSEERR_URL/OVERSEERR_API_KEY for legacy
+         - SEERR_URL=http://YOUR_UNRAID_IP:5055
+         - SEERR_API_KEY=your-seerr-api-key
          - TAUTULLI_URL=http://YOUR_UNRAID_IP:8181
          - TAUTULLI_API_KEY=your-tautulli-api-key
          - SESSION_SECRET=your-generated-secret-from-above
@@ -172,18 +185,18 @@ Requires the [**Compose Manager**](https://forums.unraid.net/topic/114415-plugin
 
    **Environment variables** (add one at a time):
 
-   | Config Type | Name              | Key                 | Value                                   |
-   | ----------- | ----------------- | ------------------- | --------------------------------------- |
-   | Variable    | Overseerr URL     | `OVERSEERR_URL`     | `http://YOUR_UNRAID_IP:5055`            |
-   | Variable    | Overseerr API Key | `OVERSEERR_API_KEY` | Your Overseerr API key                  |
-   | Variable    | Tautulli URL      | `TAUTULLI_URL`      | `http://YOUR_UNRAID_IP:8181`            |
-   | Variable    | Tautulli API Key  | `TAUTULLI_API_KEY`  | Your Tautulli API key                   |
-   | Variable    | Session Secret    | `SESSION_SECRET`    | Your generated secret                   |
-   | Variable    | Sonarr URL        | `SONARR_URL`        | `http://YOUR_UNRAID_IP:8989` (optional) |
-   | Variable    | Sonarr API Key    | `SONARR_API_KEY`    | Your Sonarr API key (optional)          |
-   | Variable    | Radarr URL        | `RADARR_URL`        | `http://YOUR_UNRAID_IP:7878` (optional) |
-   | Variable    | Radarr API Key    | `RADARR_API_KEY`    | Your Radarr API key (optional)          |
-   | Variable    | Debug Logging     | `DEBUG`             | `true` (optional)                       |
+   | Config Type | Name             | Key                | Value                                                        |
+   | ----------- | ---------------- | ------------------ | ------------------------------------------------------------ |
+   | Variable    | Seerr URL        | `SEERR_URL`        | `http://YOUR_UNRAID_IP:5055` (or use `OVERSEERR_URL` legacy) |
+   | Variable    | Seerr API Key    | `SEERR_API_KEY`    | Your Seerr API key (or use `OVERSEERR_API_KEY` legacy)       |
+   | Variable    | Tautulli URL     | `TAUTULLI_URL`     | `http://YOUR_UNRAID_IP:8181`                                 |
+   | Variable    | Tautulli API Key | `TAUTULLI_API_KEY` | Your Tautulli API key                                        |
+   | Variable    | Session Secret   | `SESSION_SECRET`   | Your generated secret                                        |
+   | Variable    | Sonarr URL       | `SONARR_URL`       | `http://YOUR_UNRAID_IP:8989` (optional)                      |
+   | Variable    | Sonarr API Key   | `SONARR_API_KEY`   | Your Sonarr API key (optional)                               |
+   | Variable    | Radarr URL       | `RADARR_URL`       | `http://YOUR_UNRAID_IP:7878` (optional)                      |
+   | Variable    | Radarr API Key   | `RADARR_API_KEY`   | Your Radarr API key (optional)                               |
+   | Variable    | Debug Logging    | `DEBUG`            | `true` (optional)                                            |
 
 6. Click **Apply**
 
@@ -202,14 +215,14 @@ This imports a pre-configured template so you only need to fill in your values:
    ```
 3. Go to the **Docker** tab and click **Add Container**
 4. From the **Template** dropdown, select **shelflife**
-5. Fill in your Overseerr URL, Overseerr API Key, Tautulli URL, Tautulli API Key, and Session Secret
+5. Fill in your Seerr URL (or Overseerr URL), API Key, Tautulli URL, Tautulli API Key, and Session Secret
 6. Click **Apply**
 
 The template has all ports, paths, and optional settings pre-configured. You just fill in your credentials.
 
 ### Troubleshooting
 
-**"Connection refused" when syncing:** Your `OVERSEERR_URL` or `TAUTULLI_URL` is probably using `localhost` or `127.0.0.1`. Change it to your Unraid server's actual IP address (e.g. `http://192.168.1.100:5055`).
+**"Connection refused" when syncing:** Your `SEERR_URL` (or `OVERSEERR_URL`) or `TAUTULLI_URL` is probably using `localhost` or `127.0.0.1`. Change it to your Unraid server's actual IP address (e.g. `http://192.168.1.100:5055`).
 
 **Container starts but can't reach the web UI:** Make sure port 3000 isn't already in use by another container. You can change the host port (the left side) to something else, e.g. `3001:3000`.
 
@@ -223,5 +236,5 @@ The template has all ports, paths, and optional settings pre-configured. You jus
 2. Click **Sign in with Plex**
 3. Authorize the app in the Plex popup
 4. The first user to sign in automatically becomes the admin
-5. Go to the Admin page and click **Sync** to pull in your Overseerr requests and Tautulli watch history
+5. Go to the Admin page and click **Sync** to pull in your Seerr/Overseerr requests and Tautulli watch history
 6. Share the URL with your Plex users so they can log in and vote on their own requests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,18 @@ services:
     environment:
       - NODE_ENV=production
       - DATABASE_PATH=/app/data/shelflife.db
-      - OVERSEERR_URL=${OVERSEERR_URL}
-      - OVERSEERR_API_KEY=${OVERSEERR_API_KEY}
+      # Seerr (primary — the successor to Overseerr and Jellyseerr)
+      - SEERR_URL=${SEERR_URL:-}
+      - SEERR_API_KEY=${SEERR_API_KEY:-}
+      - NEXT_PUBLIC_SEERR_URL=${NEXT_PUBLIC_SEERR_URL:-}
+      # Overseerr (legacy fallback)
+      - OVERSEERR_URL=${OVERSEERR_URL:-}
+      - OVERSEERR_API_KEY=${OVERSEERR_API_KEY:-}
+      - NEXT_PUBLIC_OVERSEERR_URL=${NEXT_PUBLIC_OVERSEERR_URL:-}
+      # Jellyseerr (legacy fallback)
+      - JELLYSEERR_URL=${JELLYSEERR_URL:-}
+      - JELLYSEERR_API_KEY=${JELLYSEERR_API_KEY:-}
+      - NEXT_PUBLIC_JELLYSEERR_URL=${NEXT_PUBLIC_JELLYSEERR_URL:-}
       - TAUTULLI_URL=${TAUTULLI_URL}
       - TAUTULLI_API_KEY=${TAUTULLI_API_KEY}
       - SONARR_URL=${SONARR_URL:-}

--- a/src/app/api/media/details/[tmdbId]/__tests__/route.test.ts
+++ b/src/app/api/media/details/[tmdbId]/__tests__/route.test.ts
@@ -27,8 +27,8 @@ vi.mock("@/lib/auth/middleware", () => ({
 
 const mockGetMediaDetails = vi.fn();
 
-vi.mock("@/lib/services/overseerr", () => ({
-  getOverseerrClient: () => ({
+vi.mock("@/lib/services/request-service", () => ({
+  getRequestServiceClient: () => ({
     getMediaDetails: mockGetMediaDetails,
   }),
 }));

--- a/src/app/api/media/details/[tmdbId]/route.ts
+++ b/src/app/api/media/details/[tmdbId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth, handleAuthError } from "@/lib/auth/middleware";
-import { getOverseerrClient } from "@/lib/services/overseerr";
+import { getRequestServiceClient } from "@/lib/services/request-service";
 import { mediaDetailsQuerySchema } from "@/lib/validators/schemas";
 
 export async function GET(
@@ -28,7 +28,7 @@ export async function GET(
       );
     }
 
-    const client = getOverseerrClient();
+    const client = getRequestServiceClient();
     const details = await client.getMediaDetails(id, parsed.data.type);
 
     return NextResponse.json({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Manrope } from "next/font/google";
 import "./globals.css";
+import { ProviderLabelProvider } from "@/lib/provider-context";
+import { getProviderLabel } from "@/lib/services/request-service";
 
 const manrope = Manrope({
   subsets: ["latin"],
@@ -12,14 +14,26 @@ export const metadata: Metadata = {
   description: "Manage your Plex library storage - vote to keep or prune requested content",
 };
 
+function resolveProviderLabel(): "Seerr" | "Overseerr" | "Jellyseerr" {
+  try {
+    return getProviderLabel();
+  } catch {
+    return "Overseerr";
+  }
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const providerLabel = resolveProviderLabel();
+
   return (
     <html lang="en" className={`dark ${manrope.variable}`}>
-      <body className="min-h-screen bg-gray-950 text-gray-100 antialiased">{children}</body>
+      <body className="min-h-screen bg-gray-950 text-gray-100 antialiased">
+        <ProviderLabelProvider label={providerLabel}>{children}</ProviderLabelProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/admin/AutoSyncSettings.tsx
+++ b/src/components/admin/AutoSyncSettings.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Toast, type ToastData } from "@/components/ui/Toast";
+import { useProviderLabel } from "@/lib/provider-context";
 
 interface AutoSyncSettingsProps {
   initialSettings: {
@@ -19,18 +20,18 @@ const SCHEDULE_PRESETS: { label: string; value: string }[] = [
   { label: "Custom", value: "custom" },
 ];
 
-const SYNC_TYPES: { label: string; value: string }[] = [
-  { label: "Full", value: "full" },
-  { label: "Overseerr Only", value: "overseerr" },
-  { label: "Tautulli Only", value: "tautulli" },
-];
-
 function getPresetForSchedule(schedule: string): string {
   const preset = SCHEDULE_PRESETS.find((p) => p.value === schedule);
   return preset ? preset.value : "custom";
 }
 
 export function AutoSyncSettings({ initialSettings }: AutoSyncSettingsProps) {
+  const providerLabel = useProviderLabel();
+  const syncTypes = [
+    { label: "Full", value: "full" },
+    { label: `${providerLabel} Only`, value: "overseerr" },
+    { label: "Tautulli Only", value: "tautulli" },
+  ];
   const [enabled, setEnabled] = useState(initialSettings.enabled);
   const [schedule, setSchedule] = useState(initialSettings.schedule);
   const [selectedPreset, setSelectedPreset] = useState(
@@ -139,7 +140,7 @@ export function AutoSyncSettings({ initialSettings }: AutoSyncSettingsProps) {
               onChange={(e) => setSyncType(e.target.value as typeof syncType)}
               className="focus:border-brand w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-200 focus:outline-none"
             >
-              {SYNC_TYPES.map((t) => (
+              {syncTypes.map((t) => (
                 <option key={t.value} value={t.value}>
                   {t.label}
                 </option>

--- a/src/components/admin/DeletionConfirmDialog.tsx
+++ b/src/components/admin/DeletionConfirmDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
+import { useProviderLabel } from "@/lib/provider-context";
 
 interface DeletionConfirmDialogProps {
   title: string;
@@ -20,13 +21,14 @@ export function DeletionConfirmDialog({
   onCancel,
   isDeleting,
 }: DeletionConfirmDialogProps) {
+  const providerLabel = useProviderLabel();
   const [deleteFiles, setDeleteFiles] = useState(false);
 
   const serviceName = mediaType === "tv" ? "Sonarr" : "Radarr";
   const serviceConfigured = mediaType === "tv" ? serviceStatus.sonarr : serviceStatus.radarr;
   const services = [
     serviceConfigured && serviceName,
-    serviceStatus.overseerr && "Overseerr",
+    serviceStatus.overseerr && providerLabel,
   ].filter(Boolean);
 
   // Close on Escape key
@@ -102,7 +104,7 @@ export function DeletionConfirmDialog({
             {serviceStatus.overseerr && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-red-900/30 px-3 py-1 text-xs font-medium text-red-300">
                 <span className="h-1.5 w-1.5 rounded-full bg-red-400" />
-                Overseerr
+                {providerLabel}
               </span>
             )}
           </div>

--- a/src/components/admin/SyncStatus.tsx
+++ b/src/components/admin/SyncStatus.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Toast, type ToastData } from "@/components/ui/Toast";
+import { useProviderLabel } from "@/lib/provider-context";
 
 interface SyncStatusProps {
   lastSync?: {
@@ -38,7 +39,15 @@ export function formatSyncResult(synced: SyncResult): string {
   return `Synced ${parts.join(" and ")}`;
 }
 
+function formatSyncType(syncType: string, providerLabel: string): string {
+  if (syncType === "overseerr") return providerLabel;
+  if (syncType === "tautulli") return "Tautulli";
+  if (syncType === "full") return "Full";
+  return syncType;
+}
+
 export function SyncStatus({ lastSync }: SyncStatusProps) {
+  const providerLabel = useProviderLabel();
   const [syncing, setSyncing] = useState(false);
   const [progress, setProgress] = useState<ProgressState | null>(null);
   const [toast, setToast] = useState<ToastData | null>(null);
@@ -135,7 +144,11 @@ export function SyncStatus({ lastSync }: SyncStatusProps) {
       {lastSync && !syncing && (
         <div className="space-y-1 text-sm text-gray-400">
           <p>
-            Last sync: <span className="text-gray-200">{lastSync.syncType}</span> -{" "}
+            Last sync:{" "}
+            <span className="text-gray-200">
+              {formatSyncType(lastSync.syncType, providerLabel)}
+            </span>{" "}
+            -{" "}
             <span className={lastSync.status === "completed" ? "text-green-400" : "text-red-400"}>
               {lastSync.status}
             </span>
@@ -158,7 +171,7 @@ export function SyncStatus({ lastSync }: SyncStatusProps) {
                   : "bg-purple-900/50 text-purple-300"
               }`}
             >
-              {progress.phase === "overseerr" ? "Overseerr" : "Tautulli"}
+              {progress.phase === "overseerr" ? providerLabel : "Tautulli"}
             </span>
             <span className="text-sm text-gray-300">{progress.step}</span>
           </div>
@@ -228,7 +241,7 @@ export function SyncStatus({ lastSync }: SyncStatusProps) {
               onClick={() => triggerSync("overseerr")}
               className="rounded-md bg-gray-700 px-4 py-2 text-sm transition-colors hover:bg-gray-600"
             >
-              Overseerr Only
+              {providerLabel} Only
             </button>
             <button
               onClick={() => triggerSync("tautulli")}

--- a/src/components/ui/MediaDetailModal.tsx
+++ b/src/components/ui/MediaDetailModal.tsx
@@ -6,6 +6,8 @@ import Image from "next/image";
 import { MediaTypeBadge } from "./MediaTypeBadge";
 import { STATUS_COLORS } from "@/lib/constants";
 import { formatFileSize } from "@/lib/format";
+import { useProviderLabel } from "@/lib/provider-context";
+import { getClientProviderUrl } from "@/lib/request-provider";
 import type { MediaStatus } from "@/types";
 
 interface MediaDetailModalProps {
@@ -55,7 +57,8 @@ export function MediaDetailModal({
   onClose,
 }: MediaDetailModalProps) {
   const tmdbType = mediaType === "tv" ? "tv" : "movie";
-  const overseerrUrl = process.env.NEXT_PUBLIC_OVERSEERR_URL;
+  const providerUrl = getClientProviderUrl();
+  const providerLabel = useProviderLabel();
   const [overview, setOverview] = useState<string | null>(null);
   const [overviewLoading, setOverviewLoading] = useState(!!tmdbId);
   const onCloseRef = useRef(onClose);
@@ -273,14 +276,14 @@ export function MediaDetailModal({
                   <ExternalLinkIcon />
                 </a>
               )}
-              {overseerrId && overseerrUrl && (
+              {overseerrId && providerUrl && (
                 <a
-                  href={`${overseerrUrl}/${tmdbType}/${tmdbId}`}
+                  href={`${providerUrl}/${tmdbType}/${tmdbId}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1 text-xs text-purple-400 hover:underline"
                 >
-                  Overseerr
+                  {providerLabel}
                   <ExternalLinkIcon />
                 </a>
               )}

--- a/src/lib/provider-context.tsx
+++ b/src/lib/provider-context.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+type ProviderLabel = "Seerr" | "Overseerr" | "Jellyseerr";
+
+const ProviderLabelContext = createContext<ProviderLabel>("Overseerr");
+
+export function ProviderLabelProvider({
+  label,
+  children,
+}: {
+  label: ProviderLabel;
+  children: React.ReactNode;
+}) {
+  return <ProviderLabelContext.Provider value={label}>{children}</ProviderLabelContext.Provider>;
+}
+
+export function useProviderLabel(): ProviderLabel {
+  return useContext(ProviderLabelContext);
+}

--- a/src/lib/request-provider.ts
+++ b/src/lib/request-provider.ts
@@ -1,0 +1,20 @@
+/**
+ * Client-safe utility for deriving the public URL of the active request service provider.
+ * No server-only imports — safe for "use client" components.
+ *
+ * For the provider _label_, use the `useProviderLabel()` hook from `@/lib/provider-context`
+ * instead (it reads the server-side env vars via React context, avoiding the need for
+ * separate NEXT_PUBLIC_* variables).
+ */
+
+/**
+ * Returns the public-facing URL for the active provider, or undefined if none is set.
+ * Used for deep-linking to the Seerr/Overseerr/Jellyseerr UI.
+ */
+export function getClientProviderUrl(): string | undefined {
+  return (
+    process.env.NEXT_PUBLIC_SEERR_URL ||
+    process.env.NEXT_PUBLIC_JELLYSEERR_URL ||
+    process.env.NEXT_PUBLIC_OVERSEERR_URL
+  );
+}

--- a/src/lib/services/__tests__/deletion.test.ts
+++ b/src/lib/services/__tests__/deletion.test.ts
@@ -20,8 +20,8 @@ vi.mock("@/lib/services/sonarr", () => ({
   })),
 }));
 
-vi.mock("@/lib/services/overseerr", () => ({
-  getOverseerrClient: vi.fn(() => ({
+vi.mock("@/lib/services/request-service", () => ({
+  getRequestServiceClient: vi.fn(() => ({
     deleteMedia: vi.fn(),
   })),
 }));
@@ -52,7 +52,7 @@ describe("executeMediaDeletion", () => {
   it("deletes movie via Radarr and Overseerr", async () => {
     const { isRadarrConfigured, getRadarrClient } = await import("@/lib/services/radarr");
     const { isSonarrConfigured } = await import("@/lib/services/sonarr");
-    const { getOverseerrClient } = await import("@/lib/services/overseerr");
+    const { getRequestServiceClient } = await import("@/lib/services/request-service");
     const { executeMediaDeletion } = await import("../deletion");
 
     (isRadarrConfigured as any).mockReturnValue(true);
@@ -63,9 +63,9 @@ describe("executeMediaDeletion", () => {
     (mockRadarrClient.deleteMovie as any).mockResolvedValue(undefined);
     (getRadarrClient as any).mockReturnValue(mockRadarrClient);
 
-    const mockOverseerrClient = (getOverseerrClient as any)();
+    const mockOverseerrClient = (getRequestServiceClient as any)();
     (mockOverseerrClient.deleteMedia as any).mockResolvedValue(undefined);
-    (getOverseerrClient as any).mockReturnValue(mockOverseerrClient);
+    (getRequestServiceClient as any).mockReturnValue(mockOverseerrClient);
 
     const result = await executeMediaDeletion({
       mediaItemId: 1,
@@ -94,7 +94,7 @@ describe("executeMediaDeletion", () => {
   it("deletes TV via Sonarr and Overseerr", async () => {
     const { isRadarrConfigured } = await import("@/lib/services/radarr");
     const { isSonarrConfigured, getSonarrClient } = await import("@/lib/services/sonarr");
-    const { getOverseerrClient } = await import("@/lib/services/overseerr");
+    const { getRequestServiceClient } = await import("@/lib/services/request-service");
     const { executeMediaDeletion } = await import("../deletion");
 
     (isRadarrConfigured as any).mockReturnValue(false);
@@ -105,9 +105,9 @@ describe("executeMediaDeletion", () => {
     (mockSonarrClient.deleteSeries as any).mockResolvedValue(undefined);
     (getSonarrClient as any).mockReturnValue(mockSonarrClient);
 
-    const mockOverseerrClient = (getOverseerrClient as any)();
+    const mockOverseerrClient = (getRequestServiceClient as any)();
     (mockOverseerrClient.deleteMedia as any).mockResolvedValue(undefined);
-    (getOverseerrClient as any).mockReturnValue(mockOverseerrClient);
+    (getRequestServiceClient as any).mockReturnValue(mockOverseerrClient);
 
     const result = await executeMediaDeletion({
       mediaItemId: 2,
@@ -130,7 +130,7 @@ describe("executeMediaDeletion", () => {
   it("handles partial failure (Radarr fails, Overseerr succeeds)", async () => {
     const { isRadarrConfigured, getRadarrClient } = await import("@/lib/services/radarr");
     const { isSonarrConfigured } = await import("@/lib/services/sonarr");
-    const { getOverseerrClient } = await import("@/lib/services/overseerr");
+    const { getRequestServiceClient } = await import("@/lib/services/request-service");
     const { executeMediaDeletion } = await import("../deletion");
 
     (isRadarrConfigured as any).mockReturnValue(true);
@@ -142,9 +142,9 @@ describe("executeMediaDeletion", () => {
     );
     (getRadarrClient as any).mockReturnValue(mockRadarrClient);
 
-    const mockOverseerrClient = (getOverseerrClient as any)();
+    const mockOverseerrClient = (getRequestServiceClient as any)();
     (mockOverseerrClient.deleteMedia as any).mockResolvedValue(undefined);
-    (getOverseerrClient as any).mockReturnValue(mockOverseerrClient);
+    (getRequestServiceClient as any).mockReturnValue(mockOverseerrClient);
 
     const result = await executeMediaDeletion({
       mediaItemId: 1,
@@ -166,7 +166,7 @@ describe("executeMediaDeletion", () => {
   it("handles item not found in external service as success", async () => {
     const { isRadarrConfigured, getRadarrClient } = await import("@/lib/services/radarr");
     const { isSonarrConfigured } = await import("@/lib/services/sonarr");
-    const { getOverseerrClient } = await import("@/lib/services/overseerr");
+    const { getRequestServiceClient } = await import("@/lib/services/request-service");
     const { executeMediaDeletion } = await import("../deletion");
 
     (isRadarrConfigured as any).mockReturnValue(true);
@@ -177,9 +177,9 @@ describe("executeMediaDeletion", () => {
     (mockRadarrClient.lookupByTmdbId as any).mockResolvedValue(null);
     (getRadarrClient as any).mockReturnValue(mockRadarrClient);
 
-    const mockOverseerrClient = (getOverseerrClient as any)();
+    const mockOverseerrClient = (getRequestServiceClient as any)();
     (mockOverseerrClient.deleteMedia as any).mockResolvedValue(undefined);
-    (getOverseerrClient as any).mockReturnValue(mockOverseerrClient);
+    (getRequestServiceClient as any).mockReturnValue(mockOverseerrClient);
 
     const result = await executeMediaDeletion({
       mediaItemId: 1,
@@ -195,15 +195,15 @@ describe("executeMediaDeletion", () => {
   it("skips Sonarr when not configured", async () => {
     const { isRadarrConfigured } = await import("@/lib/services/radarr");
     const { isSonarrConfigured } = await import("@/lib/services/sonarr");
-    const { getOverseerrClient } = await import("@/lib/services/overseerr");
+    const { getRequestServiceClient } = await import("@/lib/services/request-service");
     const { executeMediaDeletion } = await import("../deletion");
 
     (isRadarrConfigured as any).mockReturnValue(false);
     (isSonarrConfigured as any).mockReturnValue(false);
 
-    const mockOverseerrClient = (getOverseerrClient as any)();
+    const mockOverseerrClient = (getRequestServiceClient as any)();
     (mockOverseerrClient.deleteMedia as any).mockResolvedValue(undefined);
-    (getOverseerrClient as any).mockReturnValue(mockOverseerrClient);
+    (getRequestServiceClient as any).mockReturnValue(mockOverseerrClient);
 
     const result = await executeMediaDeletion({
       mediaItemId: 2,
@@ -246,7 +246,7 @@ describe("executeMediaDeletion", () => {
   it("writes deletion_log with errors", async () => {
     const { isRadarrConfigured, getRadarrClient } = await import("@/lib/services/radarr");
     const { isSonarrConfigured } = await import("@/lib/services/sonarr");
-    const { getOverseerrClient } = await import("@/lib/services/overseerr");
+    const { getRequestServiceClient } = await import("@/lib/services/request-service");
     const { executeMediaDeletion } = await import("../deletion");
 
     (isRadarrConfigured as any).mockReturnValue(true);
@@ -256,9 +256,9 @@ describe("executeMediaDeletion", () => {
     (mockRadarrClient.lookupByTmdbId as any).mockRejectedValue(new Error("Radarr timeout"));
     (getRadarrClient as any).mockReturnValue(mockRadarrClient);
 
-    const mockOverseerrClient = (getOverseerrClient as any)();
+    const mockOverseerrClient = (getRequestServiceClient as any)();
     (mockOverseerrClient.deleteMedia as any).mockResolvedValue(undefined);
-    (getOverseerrClient as any).mockReturnValue(mockOverseerrClient);
+    (getRequestServiceClient as any).mockReturnValue(mockOverseerrClient);
 
     await executeMediaDeletion({
       mediaItemId: 1,

--- a/src/lib/services/__tests__/jellyseerr.test.ts
+++ b/src/lib/services/__tests__/jellyseerr.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mapMediaStatus } from "../jellyseerr";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("mapMediaStatus (jellyseerr)", () => {
+  it("maps 1 to 'unknown'", () => {
+    expect(mapMediaStatus(1)).toBe("unknown");
+  });
+
+  it("maps 5 to 'available'", () => {
+    expect(mapMediaStatus(5)).toBe("available");
+  });
+
+  it("returns 'unknown' for null", () => {
+    expect(mapMediaStatus(null)).toBe("unknown");
+  });
+});
+
+describe("JellyseerrClient", () => {
+  let getJellyseerrClient: () => any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("../jellyseerr");
+    getJellyseerrClient = mod.getJellyseerrClient;
+  });
+
+  it("throws without env vars", async () => {
+    const origUrl = process.env.JELLYSEERR_URL;
+    const origKey = process.env.JELLYSEERR_API_KEY;
+    delete process.env.JELLYSEERR_URL;
+    delete process.env.JELLYSEERR_API_KEY;
+
+    vi.resetModules();
+    const mod = await import("../jellyseerr");
+    expect(() => mod.getJellyseerrClient()).toThrow(
+      "JELLYSEERR_URL and JELLYSEERR_API_KEY must be set"
+    );
+
+    process.env.JELLYSEERR_URL = origUrl;
+    process.env.JELLYSEERR_API_KEY = origKey;
+  });
+
+  it("getRequests returns parsed page with pagination", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({
+          pageInfo: { pages: 1, pageSize: 20, results: 1, page: 1 },
+          results: [
+            {
+              id: 1,
+              status: 2,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-02",
+              type: "movie",
+              media: { id: 10, tmdbId: 100, status: 5 },
+              requestedBy: { id: 1, plexId: 42, plexUsername: "user1" },
+            },
+          ],
+        }),
+    });
+
+    const client = getJellyseerrClient();
+    const result = await client.getRequests();
+    expect(result.pageInfo.results).toBe(1);
+    expect(result.results).toHaveLength(1);
+  });
+
+  it("throws on non-200 response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const client = getJellyseerrClient();
+    await expect(client.getRequests()).rejects.toThrow("Jellyseerr API error: 500");
+  });
+});

--- a/src/lib/services/__tests__/request-service.test.ts
+++ b/src/lib/services/__tests__/request-service.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("request-service", () => {
+  const origSeerrUrl = process.env.SEERR_URL;
+  const origSeerrKey = process.env.SEERR_API_KEY;
+  const origOverseerrUrl = process.env.OVERSEERR_URL;
+  const origOverseerrKey = process.env.OVERSEERR_API_KEY;
+  const origJellyseerrUrl = process.env.JELLYSEERR_URL;
+  const origJellyseerrKey = process.env.JELLYSEERR_API_KEY;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    // Restore original env vars
+    if (origSeerrUrl !== undefined) process.env.SEERR_URL = origSeerrUrl;
+    else delete process.env.SEERR_URL;
+    if (origSeerrKey !== undefined) process.env.SEERR_API_KEY = origSeerrKey;
+    else delete process.env.SEERR_API_KEY;
+    if (origOverseerrUrl !== undefined) process.env.OVERSEERR_URL = origOverseerrUrl;
+    else delete process.env.OVERSEERR_URL;
+    if (origOverseerrKey !== undefined) process.env.OVERSEERR_API_KEY = origOverseerrKey;
+    else delete process.env.OVERSEERR_API_KEY;
+    if (origJellyseerrUrl !== undefined) process.env.JELLYSEERR_URL = origJellyseerrUrl;
+    else delete process.env.JELLYSEERR_URL;
+    if (origJellyseerrKey !== undefined) process.env.JELLYSEERR_API_KEY = origJellyseerrKey;
+    else delete process.env.JELLYSEERR_API_KEY;
+  });
+
+  function clearAllProviderEnvVars() {
+    delete process.env.SEERR_URL;
+    delete process.env.SEERR_API_KEY;
+    delete process.env.OVERSEERR_URL;
+    delete process.env.OVERSEERR_API_KEY;
+    delete process.env.JELLYSEERR_URL;
+    delete process.env.JELLYSEERR_API_KEY;
+  }
+
+  describe("getActiveProvider", () => {
+    it("returns 'seerr' when SEERR env vars are set", async () => {
+      process.env.SEERR_URL = "http://seerr:5055";
+      process.env.SEERR_API_KEY = "seerr-key";
+      clearAllProviderEnvVars();
+      process.env.SEERR_URL = "http://seerr:5055";
+      process.env.SEERR_API_KEY = "seerr-key";
+
+      const { getActiveProvider } = await import("../request-service");
+      expect(getActiveProvider()).toBe("seerr");
+    });
+
+    it("returns 'overseerr' when only OVERSEERR env vars are set", async () => {
+      clearAllProviderEnvVars();
+      process.env.OVERSEERR_URL = "http://overseerr:5055";
+      process.env.OVERSEERR_API_KEY = "overseerr-key";
+
+      const { getActiveProvider } = await import("../request-service");
+      expect(getActiveProvider()).toBe("overseerr");
+    });
+
+    it("returns 'jellyseerr' when only JELLYSEERR env vars are set", async () => {
+      clearAllProviderEnvVars();
+      process.env.JELLYSEERR_URL = "http://jellyseerr:5055";
+      process.env.JELLYSEERR_API_KEY = "jellyseerr-key";
+
+      const { getActiveProvider } = await import("../request-service");
+      expect(getActiveProvider()).toBe("jellyseerr");
+    });
+
+    it("returns 'seerr' when all three are configured (seerr takes priority)", async () => {
+      process.env.SEERR_URL = "http://seerr:5055";
+      process.env.SEERR_API_KEY = "seerr-key";
+      process.env.OVERSEERR_URL = "http://overseerr:5055";
+      process.env.OVERSEERR_API_KEY = "overseerr-key";
+      process.env.JELLYSEERR_URL = "http://jellyseerr:5055";
+      process.env.JELLYSEERR_API_KEY = "jellyseerr-key";
+
+      const { getActiveProvider } = await import("../request-service");
+      expect(getActiveProvider()).toBe("seerr");
+    });
+
+    it("throws when none is configured", async () => {
+      clearAllProviderEnvVars();
+
+      const { getActiveProvider } = await import("../request-service");
+      expect(() => getActiveProvider()).toThrow("No request service configured");
+    });
+
+    it("falls back to overseerr when SEERR_URL is set but SEERR_API_KEY is missing", async () => {
+      clearAllProviderEnvVars();
+      process.env.SEERR_URL = "http://seerr:5055";
+      process.env.OVERSEERR_URL = "http://overseerr:5055";
+      process.env.OVERSEERR_API_KEY = "overseerr-key";
+
+      const { getActiveProvider } = await import("../request-service");
+      expect(getActiveProvider()).toBe("overseerr");
+    });
+
+    it("falls back to jellyseerr when seerr and overseerr are incomplete", async () => {
+      clearAllProviderEnvVars();
+      process.env.SEERR_URL = "http://seerr:5055";
+      // SEERR_API_KEY missing
+      process.env.OVERSEERR_URL = "http://overseerr:5055";
+      // OVERSEERR_API_KEY missing
+      process.env.JELLYSEERR_URL = "http://jellyseerr:5055";
+      process.env.JELLYSEERR_API_KEY = "jellyseerr-key";
+
+      const { getActiveProvider } = await import("../request-service");
+      expect(getActiveProvider()).toBe("jellyseerr");
+    });
+  });
+
+  describe("getProviderLabel", () => {
+    it("returns 'Seerr' when seerr is active", async () => {
+      clearAllProviderEnvVars();
+      process.env.SEERR_URL = "http://seerr:5055";
+      process.env.SEERR_API_KEY = "seerr-key";
+
+      const { getProviderLabel } = await import("../request-service");
+      expect(getProviderLabel()).toBe("Seerr");
+    });
+
+    it("returns 'Overseerr' when overseerr is active", async () => {
+      clearAllProviderEnvVars();
+      process.env.OVERSEERR_URL = "http://overseerr:5055";
+      process.env.OVERSEERR_API_KEY = "overseerr-key";
+
+      const { getProviderLabel } = await import("../request-service");
+      expect(getProviderLabel()).toBe("Overseerr");
+    });
+
+    it("returns 'Jellyseerr' when jellyseerr is active", async () => {
+      clearAllProviderEnvVars();
+      process.env.JELLYSEERR_URL = "http://jellyseerr:5055";
+      process.env.JELLYSEERR_API_KEY = "jellyseerr-key";
+
+      const { getProviderLabel } = await import("../request-service");
+      expect(getProviderLabel()).toBe("Jellyseerr");
+    });
+  });
+
+  describe("getRequestServiceClient", () => {
+    it("returns a client when seerr is configured", async () => {
+      clearAllProviderEnvVars();
+      process.env.SEERR_URL = "http://seerr:5055";
+      process.env.SEERR_API_KEY = "seerr-key";
+
+      const { getRequestServiceClient } = await import("../request-service");
+      const client = getRequestServiceClient();
+      expect(client).toBeDefined();
+      expect(typeof client.getAllRequests).toBe("function");
+      expect(typeof client.getMediaDetails).toBe("function");
+      expect(typeof client.deleteMedia).toBe("function");
+    });
+
+    it("returns a client when overseerr is configured", async () => {
+      clearAllProviderEnvVars();
+      process.env.OVERSEERR_URL = "http://overseerr:5055";
+      process.env.OVERSEERR_API_KEY = "overseerr-key";
+
+      const { getRequestServiceClient } = await import("../request-service");
+      const client = getRequestServiceClient();
+      expect(client).toBeDefined();
+      expect(typeof client.getAllRequests).toBe("function");
+    });
+
+    it("returns a client when jellyseerr is configured", async () => {
+      clearAllProviderEnvVars();
+      process.env.JELLYSEERR_URL = "http://jellyseerr:5055";
+      process.env.JELLYSEERR_API_KEY = "jellyseerr-key";
+
+      const { getRequestServiceClient } = await import("../request-service");
+      const client = getRequestServiceClient();
+      expect(client).toBeDefined();
+      expect(typeof client.getAllRequests).toBe("function");
+    });
+
+    it("throws when none is configured", async () => {
+      clearAllProviderEnvVars();
+
+      const { getRequestServiceClient } = await import("../request-service");
+      expect(() => getRequestServiceClient()).toThrow("No request service configured");
+    });
+  });
+});

--- a/src/lib/services/__tests__/seerr.test.ts
+++ b/src/lib/services/__tests__/seerr.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mapMediaStatus } from "../seerr";
+
+// We need to test both mapMediaStatus and SeerrClient.
+// SeerrClient uses a module-level singleton, so we need to reset it between tests.
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("mapMediaStatus (seerr)", () => {
+  it("maps 1 to 'unknown'", () => {
+    expect(mapMediaStatus(1)).toBe("unknown");
+  });
+
+  it("maps 2 to 'pending'", () => {
+    expect(mapMediaStatus(2)).toBe("pending");
+  });
+
+  it("maps 3 to 'processing'", () => {
+    expect(mapMediaStatus(3)).toBe("processing");
+  });
+
+  it("maps 4 to 'partial'", () => {
+    expect(mapMediaStatus(4)).toBe("partial");
+  });
+
+  it("maps 5 to 'available'", () => {
+    expect(mapMediaStatus(5)).toBe("available");
+  });
+
+  it("returns 'unknown' for null", () => {
+    expect(mapMediaStatus(null)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for undefined", () => {
+    expect(mapMediaStatus(undefined)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for 0", () => {
+    expect(mapMediaStatus(0)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for unmapped values", () => {
+    expect(mapMediaStatus(99)).toBe("unknown");
+  });
+});
+
+describe("SeerrClient", () => {
+  // Reset the module-level singleton between tests
+  let getSeerrClient: () => any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("../seerr");
+    getSeerrClient = mod.getSeerrClient;
+  });
+
+  it("throws without env vars", async () => {
+    const origUrl = process.env.SEERR_URL;
+    const origKey = process.env.SEERR_API_KEY;
+    delete process.env.SEERR_URL;
+    delete process.env.SEERR_API_KEY;
+
+    vi.resetModules();
+    const mod = await import("../seerr");
+    expect(() => mod.getSeerrClient()).toThrow("SEERR_URL and SEERR_API_KEY must be set");
+
+    process.env.SEERR_URL = origUrl;
+    process.env.SEERR_API_KEY = origKey;
+  });
+
+  it("getRequests returns parsed page with pagination", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({
+          pageInfo: { pages: 1, pageSize: 20, results: 1, page: 1 },
+          results: [
+            {
+              id: 1,
+              status: 2,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-02",
+              type: "movie",
+              media: { id: 10, tmdbId: 100, status: 5 },
+              requestedBy: { id: 1, plexId: 42, plexUsername: "user1" },
+            },
+          ],
+        }),
+    });
+
+    const client = getSeerrClient();
+    const result = await client.getRequests();
+    expect(result.pageInfo.results).toBe(1);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].type).toBe("movie");
+  });
+
+  it("getAllRequests handles single page", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({
+          pageInfo: { pages: 1, pageSize: 50, results: 2, page: 1 },
+          results: [
+            { id: 1, status: 2, createdAt: "2024-01-01", updatedAt: "2024-01-02", type: "movie" },
+            { id: 2, status: 2, createdAt: "2024-01-01", updatedAt: "2024-01-02", type: "tv" },
+          ],
+        }),
+    });
+
+    const client = getSeerrClient();
+    const results = await client.getAllRequests();
+    expect(results).toHaveLength(2);
+  });
+
+  it("getAllRequests paginates multiple pages", async () => {
+    // Page 1: 50 results out of 75 total
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({
+          pageInfo: { pages: 2, pageSize: 50, results: 75, page: 1 },
+          results: Array.from({ length: 50 }, (_, i) => ({
+            id: i + 1,
+            status: 2,
+            createdAt: "2024-01-01",
+            updatedAt: "2024-01-02",
+            type: "movie",
+          })),
+        }),
+    });
+    // Page 2: remaining 25
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({
+          pageInfo: { pages: 2, pageSize: 50, results: 75, page: 2 },
+          results: Array.from({ length: 25 }, (_, i) => ({
+            id: i + 51,
+            status: 2,
+            createdAt: "2024-01-01",
+            updatedAt: "2024-01-02",
+            type: "tv",
+          })),
+        }),
+    });
+
+    const client = getSeerrClient();
+    const results = await client.getAllRequests();
+    expect(results).toHaveLength(75);
+  });
+
+  it("getMediaDetails uses correct path for movie", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({
+          id: 100,
+          title: "Test Movie",
+          posterPath: "/poster.jpg",
+        }),
+    });
+
+    const client = getSeerrClient();
+    const details = await client.getMediaDetails(100, "movie");
+    expect(details.title).toBe("Test Movie");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/movie/100"),
+      expect.any(Object)
+    );
+  });
+
+  it("getMediaDetails uses correct path for tv", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({
+          id: 200,
+          name: "Test Show",
+        }),
+    });
+
+    const client = getSeerrClient();
+    const details = await client.getMediaDetails(200, "tv");
+    expect(details.name).toBe("Test Show");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/tv/200"),
+      expect.any(Object)
+    );
+  });
+
+  it("throws on non-200 response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const client = getSeerrClient();
+    await expect(client.getRequests()).rejects.toThrow("Seerr API error: 500");
+  });
+
+  it("throws on Zod validation failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ totally: "wrong" }),
+    });
+
+    const client = getSeerrClient();
+    await expect(client.getRequests()).rejects.toThrow();
+  });
+});

--- a/src/lib/services/__tests__/sync.test.ts
+++ b/src/lib/services/__tests__/sync.test.ts
@@ -16,11 +16,6 @@ const mockGetMediaDetails = vi.fn();
 const mockGetOverseerrUsers = vi.fn();
 
 vi.mock("../overseerr", () => ({
-  getOverseerrClient: () => ({
-    getAllRequests: mockGetAllRequests,
-    getMediaDetails: mockGetMediaDetails,
-    getUsers: mockGetOverseerrUsers,
-  }),
   mapMediaStatus: (status: number | null | undefined) => {
     const map: Record<number, string> = {
       1: "unknown",
@@ -31,6 +26,15 @@ vi.mock("../overseerr", () => ({
     };
     return map[status ?? 1] || "unknown";
   },
+}));
+
+vi.mock("../request-service", () => ({
+  getRequestServiceClient: () => ({
+    getAllRequests: mockGetAllRequests,
+    getMediaDetails: mockGetMediaDetails,
+    getUsers: mockGetOverseerrUsers,
+  }),
+  getProviderLabel: () => "Overseerr",
 }));
 
 const mockGetHistory = vi.fn();

--- a/src/lib/services/deletion.ts
+++ b/src/lib/services/deletion.ts
@@ -4,7 +4,7 @@ import { eq, and, ne } from "drizzle-orm";
 import type { DeletionResult, DeletionServiceStatus } from "@/types";
 import { isSonarrConfigured, getSonarrClient } from "./sonarr";
 import { isRadarrConfigured, getRadarrClient } from "./radarr";
-import { getOverseerrClient } from "./overseerr";
+import { getRequestServiceClient } from "./request-service";
 
 export function getDeletionServiceStatus(): DeletionServiceStatus {
   return {
@@ -106,7 +106,7 @@ export async function executeMediaDeletion(params: {
   if (mediaItem.overseerrId) {
     result.overseerr.attempted = true;
     try {
-      const client = getOverseerrClient();
+      const client = getRequestServiceClient();
       await client.deleteMedia(mediaItem.overseerrId);
       result.overseerr.success = true;
     } catch (e) {

--- a/src/lib/services/jellyseerr.ts
+++ b/src/lib/services/jellyseerr.ts
@@ -1,0 +1,201 @@
+import { z } from "zod";
+
+const jellyseerrUserSchema = z.object({
+  id: z.number(),
+  email: z.string().nullish(),
+  plexUsername: z.string().nullish(),
+  username: z.string().nullish(),
+  plexId: z.number().nullish(),
+  avatar: z.string().nullish(),
+  requestCount: z.number().nullish(),
+});
+
+const jellyseerrMediaInfoSchema = z.object({
+  id: z.number().nullish(),
+  tmdbId: z.number().nullish(),
+  tvdbId: z.number().nullish(),
+  status: z.number().nullish(),
+  ratingKey: z.string().nullish(),
+  externalServiceId: z.number().nullish(),
+});
+
+const jellyseerrRequestSchema = z.object({
+  id: z.number(),
+  status: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  type: z.enum(["movie", "tv"]),
+  media: z
+    .object({
+      id: z.number().nullish(),
+      tmdbId: z.number().nullish(),
+      tvdbId: z.number().nullish(),
+      status: z.number().nullish(),
+      mediaType: z.string().nullish(),
+      ratingKey: z.string().nullish(),
+      externalServiceSlug: z.string().nullish(),
+    })
+    .nullish(),
+  requestedBy: jellyseerrUserSchema.nullish(),
+  mediaInfo: jellyseerrMediaInfoSchema.nullish(),
+});
+
+const jellyseerrPageSchema = z.object({
+  pageInfo: z.object({
+    pages: z.number(),
+    pageSize: z.number(),
+    results: z.number(),
+    page: z.number(),
+  }),
+  results: z.array(jellyseerrRequestSchema),
+});
+
+const jellyseerrUserPageSchema = z.object({
+  pageInfo: z.object({
+    pages: z.number(),
+    pageSize: z.number(),
+    results: z.number(),
+    page: z.number(),
+  }),
+  results: z.array(jellyseerrUserSchema),
+});
+
+// Media info response with title
+const jellyseerrMediaDetailSchema = z.object({
+  id: z.number(),
+  mediaType: z.string().nullish(),
+  title: z.string().nullish(),
+  name: z.string().nullish(),
+  originalTitle: z.string().nullish(),
+  originalName: z.string().nullish(),
+  posterPath: z.string().nullish(),
+  overview: z.string().nullish(),
+  imdbId: z.string().nullish(),
+  numberOfSeasons: z.number().nullish(),
+  externalIds: z
+    .object({
+      imdbId: z.string().nullish(),
+    })
+    .nullish(),
+  mediaInfo: z
+    .object({
+      seasons: z
+        .array(
+          z.object({
+            seasonNumber: z.number(),
+            status: z.number(),
+          })
+        )
+        .nullish(),
+    })
+    .nullish(),
+});
+
+export type JellyseerrRequest = z.infer<typeof jellyseerrRequestSchema>;
+export type JellyseerrUser = z.infer<typeof jellyseerrUserSchema>;
+
+type MediaStatusValue = "unknown" | "pending" | "processing" | "partial" | "available";
+
+const MEDIA_STATUS_MAP: Record<number, MediaStatusValue> = {
+  1: "unknown",
+  2: "pending",
+  3: "processing",
+  4: "partial",
+  5: "available",
+};
+
+export function mapMediaStatus(status: number | null | undefined): MediaStatusValue {
+  return MEDIA_STATUS_MAP[status ?? 1] || "unknown";
+}
+
+class JellyseerrClient {
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor() {
+    const url = process.env.JELLYSEERR_URL;
+    const key = process.env.JELLYSEERR_API_KEY;
+    if (!url || !key) {
+      throw new Error("JELLYSEERR_URL and JELLYSEERR_API_KEY must be set");
+    }
+    this.baseUrl = url.replace(/\/$/, "");
+    this.apiKey = key;
+  }
+
+  private async fetch(path: string, options?: RequestInit) {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      ...options,
+      headers: {
+        "X-Api-Key": this.apiKey,
+        Accept: "application/json",
+        ...options?.headers,
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`Jellyseerr API error: ${res.status} ${res.statusText}`);
+    }
+    const contentType = res.headers.get("content-type");
+    if (contentType?.includes("application/json")) {
+      return res.json();
+    }
+    return null;
+  }
+
+  async deleteMedia(overseerrMediaId: number): Promise<void> {
+    await this.fetch(`/api/v1/media/${overseerrMediaId}`, { method: "DELETE" });
+  }
+
+  async getRequests(take = 20, skip = 0): Promise<z.infer<typeof jellyseerrPageSchema>> {
+    const data = await this.fetch(
+      `/api/v1/request?take=${take}&skip=${skip}&sort=added&filter=all`
+    );
+    return jellyseerrPageSchema.parse(data);
+  }
+
+  async getAllRequests(): Promise<JellyseerrRequest[]> {
+    const allRequests: JellyseerrRequest[] = [];
+    let skip = 0;
+    const take = 50;
+
+    while (true) {
+      const page = await this.getRequests(take, skip);
+      allRequests.push(...page.results);
+      if (skip + take >= page.pageInfo.results) break;
+      skip += take;
+    }
+
+    return allRequests;
+  }
+
+  async getMediaDetails(
+    tmdbId: number,
+    mediaType: string
+  ): Promise<z.infer<typeof jellyseerrMediaDetailSchema>> {
+    const data = await this.fetch(`/api/v1/${mediaType}/${tmdbId}`);
+    return jellyseerrMediaDetailSchema.parse(data);
+  }
+
+  async getUsers(): Promise<JellyseerrUser[]> {
+    const allUsers: JellyseerrUser[] = [];
+    let page = 1;
+
+    while (true) {
+      const data = await this.fetch(`/api/v1/user?take=50&skip=${(page - 1) * 50}`);
+      const parsed = jellyseerrUserPageSchema.parse(data);
+      allUsers.push(...parsed.results);
+      if (page >= parsed.pageInfo.pages) break;
+      page++;
+    }
+
+    return allUsers;
+  }
+}
+
+let client: JellyseerrClient | null = null;
+
+export function getJellyseerrClient(): JellyseerrClient {
+  if (!client) {
+    client = new JellyseerrClient();
+  }
+  return client;
+}

--- a/src/lib/services/request-service.ts
+++ b/src/lib/services/request-service.ts
@@ -1,0 +1,47 @@
+import { getOverseerrClient } from "./overseerr";
+import { getSeerrClient } from "./seerr";
+import { getJellyseerrClient } from "./jellyseerr";
+
+export type RequestProvider = "seerr" | "overseerr" | "jellyseerr";
+
+/**
+ * Detects which request service provider is configured.
+ * Seerr takes priority; Overseerr and Jellyseerr are legacy fallbacks on the same tier.
+ * Throws if none is configured.
+ */
+export function getActiveProvider(): RequestProvider {
+  if (process.env.SEERR_URL && process.env.SEERR_API_KEY) {
+    return "seerr";
+  }
+  if (process.env.OVERSEERR_URL && process.env.OVERSEERR_API_KEY) {
+    return "overseerr";
+  }
+  if (process.env.JELLYSEERR_URL && process.env.JELLYSEERR_API_KEY) {
+    return "jellyseerr";
+  }
+  throw new Error(
+    "No request service configured. Set SEERR_URL/SEERR_API_KEY, OVERSEERR_URL/OVERSEERR_API_KEY, or JELLYSEERR_URL/JELLYSEERR_API_KEY."
+  );
+}
+
+/**
+ * Returns the appropriate client singleton based on the active provider.
+ */
+export function getRequestServiceClient(): ReturnType<
+  typeof getSeerrClient | typeof getOverseerrClient | typeof getJellyseerrClient
+> {
+  const provider = getActiveProvider();
+  if (provider === "seerr") return getSeerrClient();
+  if (provider === "jellyseerr") return getJellyseerrClient();
+  return getOverseerrClient();
+}
+
+/**
+ * Returns a user-facing label for the active provider (server-side).
+ */
+export function getProviderLabel(): "Seerr" | "Overseerr" | "Jellyseerr" {
+  const provider = getActiveProvider();
+  if (provider === "seerr") return "Seerr";
+  if (provider === "jellyseerr") return "Jellyseerr";
+  return "Overseerr";
+}

--- a/src/lib/services/seerr.ts
+++ b/src/lib/services/seerr.ts
@@ -1,0 +1,201 @@
+import { z } from "zod";
+
+const seerrUserSchema = z.object({
+  id: z.number(),
+  email: z.string().nullish(),
+  plexUsername: z.string().nullish(),
+  username: z.string().nullish(),
+  plexId: z.number().nullish(),
+  avatar: z.string().nullish(),
+  requestCount: z.number().nullish(),
+});
+
+const seerrMediaInfoSchema = z.object({
+  id: z.number().nullish(),
+  tmdbId: z.number().nullish(),
+  tvdbId: z.number().nullish(),
+  status: z.number().nullish(),
+  ratingKey: z.string().nullish(),
+  externalServiceId: z.number().nullish(),
+});
+
+const seerrRequestSchema = z.object({
+  id: z.number(),
+  status: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  type: z.enum(["movie", "tv"]),
+  media: z
+    .object({
+      id: z.number().nullish(),
+      tmdbId: z.number().nullish(),
+      tvdbId: z.number().nullish(),
+      status: z.number().nullish(),
+      mediaType: z.string().nullish(),
+      ratingKey: z.string().nullish(),
+      externalServiceSlug: z.string().nullish(),
+    })
+    .nullish(),
+  requestedBy: seerrUserSchema.nullish(),
+  mediaInfo: seerrMediaInfoSchema.nullish(),
+});
+
+const seerrPageSchema = z.object({
+  pageInfo: z.object({
+    pages: z.number(),
+    pageSize: z.number(),
+    results: z.number(),
+    page: z.number(),
+  }),
+  results: z.array(seerrRequestSchema),
+});
+
+const seerrUserPageSchema = z.object({
+  pageInfo: z.object({
+    pages: z.number(),
+    pageSize: z.number(),
+    results: z.number(),
+    page: z.number(),
+  }),
+  results: z.array(seerrUserSchema),
+});
+
+// Media info response with title
+const seerrMediaDetailSchema = z.object({
+  id: z.number(),
+  mediaType: z.string().nullish(),
+  title: z.string().nullish(),
+  name: z.string().nullish(),
+  originalTitle: z.string().nullish(),
+  originalName: z.string().nullish(),
+  posterPath: z.string().nullish(),
+  overview: z.string().nullish(),
+  imdbId: z.string().nullish(),
+  numberOfSeasons: z.number().nullish(),
+  externalIds: z
+    .object({
+      imdbId: z.string().nullish(),
+    })
+    .nullish(),
+  mediaInfo: z
+    .object({
+      seasons: z
+        .array(
+          z.object({
+            seasonNumber: z.number(),
+            status: z.number(),
+          })
+        )
+        .nullish(),
+    })
+    .nullish(),
+});
+
+export type SeerrRequest = z.infer<typeof seerrRequestSchema>;
+export type SeerrUser = z.infer<typeof seerrUserSchema>;
+
+type MediaStatusValue = "unknown" | "pending" | "processing" | "partial" | "available";
+
+const MEDIA_STATUS_MAP: Record<number, MediaStatusValue> = {
+  1: "unknown",
+  2: "pending",
+  3: "processing",
+  4: "partial",
+  5: "available",
+};
+
+export function mapMediaStatus(status: number | null | undefined): MediaStatusValue {
+  return MEDIA_STATUS_MAP[status ?? 1] || "unknown";
+}
+
+class SeerrClient {
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor() {
+    const url = process.env.SEERR_URL;
+    const key = process.env.SEERR_API_KEY;
+    if (!url || !key) {
+      throw new Error("SEERR_URL and SEERR_API_KEY must be set");
+    }
+    this.baseUrl = url.replace(/\/$/, "");
+    this.apiKey = key;
+  }
+
+  private async fetch(path: string, options?: RequestInit) {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      ...options,
+      headers: {
+        "X-Api-Key": this.apiKey,
+        Accept: "application/json",
+        ...options?.headers,
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`Seerr API error: ${res.status} ${res.statusText}`);
+    }
+    const contentType = res.headers.get("content-type");
+    if (contentType?.includes("application/json")) {
+      return res.json();
+    }
+    return null;
+  }
+
+  async deleteMedia(overseerrMediaId: number): Promise<void> {
+    await this.fetch(`/api/v1/media/${overseerrMediaId}`, { method: "DELETE" });
+  }
+
+  async getRequests(take = 20, skip = 0): Promise<z.infer<typeof seerrPageSchema>> {
+    const data = await this.fetch(
+      `/api/v1/request?take=${take}&skip=${skip}&sort=added&filter=all`
+    );
+    return seerrPageSchema.parse(data);
+  }
+
+  async getAllRequests(): Promise<SeerrRequest[]> {
+    const allRequests: SeerrRequest[] = [];
+    let skip = 0;
+    const take = 50;
+
+    while (true) {
+      const page = await this.getRequests(take, skip);
+      allRequests.push(...page.results);
+      if (skip + take >= page.pageInfo.results) break;
+      skip += take;
+    }
+
+    return allRequests;
+  }
+
+  async getMediaDetails(
+    tmdbId: number,
+    mediaType: string
+  ): Promise<z.infer<typeof seerrMediaDetailSchema>> {
+    const data = await this.fetch(`/api/v1/${mediaType}/${tmdbId}`);
+    return seerrMediaDetailSchema.parse(data);
+  }
+
+  async getUsers(): Promise<SeerrUser[]> {
+    const allUsers: SeerrUser[] = [];
+    let page = 1;
+
+    while (true) {
+      const data = await this.fetch(`/api/v1/user?take=50&skip=${(page - 1) * 50}`);
+      const parsed = seerrUserPageSchema.parse(data);
+      allUsers.push(...parsed.results);
+      if (page >= parsed.pageInfo.pages) break;
+      page++;
+    }
+
+    return allUsers;
+  }
+}
+
+let client: SeerrClient | null = null;
+
+export function getSeerrClient(): SeerrClient {
+  if (!client) {
+    client = new SeerrClient();
+  }
+  return client;
+}

--- a/src/lib/services/sync.ts
+++ b/src/lib/services/sync.ts
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { mediaItems, watchStatus, syncLog, users } from "@/lib/db/schema";
-import { getOverseerrClient, mapMediaStatus } from "./overseerr";
+import { mapMediaStatus } from "./overseerr";
+import { getRequestServiceClient, getProviderLabel } from "./request-service";
 import { getTautulliClient } from "./tautulli";
 import { upsertUser } from "./user-upsert";
 import { eq, and, ne, count, isNotNull, notInArray } from "drizzle-orm";
@@ -49,11 +50,12 @@ async function markStaleItemsRemoved(
 }
 
 export async function syncOverseerr(onProgress?: ProgressCallback): Promise<number> {
-  const client = getOverseerrClient();
+  const client = getRequestServiceClient();
+  const providerLabel = getProviderLabel();
 
   onProgress?.({
     phase: "overseerr",
-    step: "Fetching requests from Overseerr...",
+    step: `Fetching requests from ${providerLabel}...`,
     current: 0,
     total: 0,
   });

--- a/unraid/shelflife.xml
+++ b/unraid/shelflife.xml
@@ -7,18 +7,25 @@
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support/>
-  <Overview>Manage your Plex library storage. Users log in via Plex to vote on keeping or deleting content they requested through Overseerr. Admin gets a dashboard showing what can be pruned.</Overview>
+  <Overview>Manage your Plex library storage. Users log in via Plex to vote on keeping or deleting content they requested through Seerr, Overseerr, or Jellyseerr. Admin gets a dashboard showing what can be pruned.</Overview>
   <Category>MediaServer:Other</Category>
   <WebUI>http://[IP]:[PORT:3000]/</WebUI>
   <TemplateURL/>
   <Icon>https://raw.githubusercontent.com/fauxvo/shelflife/main/public/icon.png</Icon>
   <ExtraParams/>
   <DateInstalled/>
-  <Description>Shelflife - Library storage management. Connect to Overseerr and Tautulli to let users vote on which requested content to keep or delete.</Description>
+  <Description>Shelflife - Library storage management. Connect to Seerr, Overseerr, or Jellyseerr and Tautulli to let users vote on which requested content to keep or delete.</Description>
   <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Web interface port" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
   <Config Name="Data" Target="/app/data" Default="/mnt/user/appdata/shelflife" Mode="rw" Description="SQLite database and app data" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/shelflife</Config>
-  <Config Name="Overseerr URL" Target="OVERSEERR_URL" Default="http://192.168.1.x:5055" Mode="" Description="URL of your Overseerr instance" Type="Variable" Display="always" Required="true" Mask="false">http://192.168.1.x:5055</Config>
-  <Config Name="Overseerr API Key" Target="OVERSEERR_API_KEY" Default="" Mode="" Description="Overseerr API key (Settings > General in Overseerr)" Type="Variable" Display="always" Required="true" Mask="true"></Config>
+  <Config Name="Seerr URL" Target="SEERR_URL" Default="http://192.168.1.x:5055" Mode="" Description="URL of your Seerr instance (recommended — the successor to Overseerr and Jellyseerr)" Type="Variable" Display="always" Required="false" Mask="false"></Config>
+  <Config Name="Seerr API Key" Target="SEERR_API_KEY" Default="" Mode="" Description="Seerr API key (Settings > General in Seerr)" Type="Variable" Display="always" Required="false" Mask="true"></Config>
+  <Config Name="Seerr Public URL" Target="NEXT_PUBLIC_SEERR_URL" Default="" Mode="" Description="Public URL of your Seerr instance (for linking from the UI)" Type="Variable" Display="always" Required="false" Mask="false"></Config>
+  <Config Name="Overseerr URL" Target="OVERSEERR_URL" Default="http://192.168.1.x:5055" Mode="" Description="URL of your Overseerr instance (legacy fallback — used if Seerr is not configured)" Type="Variable" Display="always" Required="false" Mask="false"></Config>
+  <Config Name="Overseerr API Key" Target="OVERSEERR_API_KEY" Default="" Mode="" Description="Overseerr API key (Settings > General in Overseerr)" Type="Variable" Display="always" Required="false" Mask="true"></Config>
+  <Config Name="Overseerr Public URL" Target="NEXT_PUBLIC_OVERSEERR_URL" Default="" Mode="" Description="Public URL of your Overseerr instance (legacy fallback for linking from the UI)" Type="Variable" Display="always" Required="false" Mask="false"></Config>
+  <Config Name="Jellyseerr URL" Target="JELLYSEERR_URL" Default="" Mode="" Description="URL of your Jellyseerr instance (legacy fallback — used if Seerr is not configured)" Type="Variable" Display="always" Required="false" Mask="false"></Config>
+  <Config Name="Jellyseerr API Key" Target="JELLYSEERR_API_KEY" Default="" Mode="" Description="Jellyseerr API key (Settings > General in Jellyseerr)" Type="Variable" Display="always" Required="false" Mask="true"></Config>
+  <Config Name="Jellyseerr Public URL" Target="NEXT_PUBLIC_JELLYSEERR_URL" Default="" Mode="" Description="Public URL of your Jellyseerr instance (legacy fallback for linking from the UI)" Type="Variable" Display="always" Required="false" Mask="false"></Config>
   <Config Name="Tautulli URL" Target="TAUTULLI_URL" Default="http://192.168.1.x:8181" Mode="" Description="URL of your Tautulli instance" Type="Variable" Display="always" Required="true" Mask="false">http://192.168.1.x:8181</Config>
   <Config Name="Tautulli API Key" Target="TAUTULLI_API_KEY" Default="" Mode="" Description="Tautulli API key (Settings > Web Interface in Tautulli)" Type="Variable" Display="always" Required="true" Mask="true"></Config>
   <Config Name="Session Secret" Target="SESSION_SECRET" Default="" Mode="" Description="Random string for JWT signing (minimum 32 characters)" Type="Variable" Display="always" Required="true" Mask="true"></Config>


### PR DESCRIPTION
## Summary

- Adds **Seerr** as the primary request service provider, with **Overseerr** and **Jellyseerr** as same-tier legacy fallbacks
- Auto-detects the active provider from env vars (priority: Seerr > Overseerr > Jellyseerr)
- All UI labels dynamically reflect the configured provider — no more hardcoded "Overseerr" text
- Internal values (DB columns, SyncType enum, sync phases) remain unchanged for backwards compatibility

### New files
- `src/lib/services/seerr.ts` — Seerr API client
- `src/lib/services/jellyseerr.ts` — Jellyseerr API client
- `src/lib/services/request-service.ts` — provider resolver (auto-detects from env vars)
- `src/lib/provider-context.tsx` — React context so client components get the label from server-side env vars
- `src/lib/request-provider.ts` — client-safe utility for the provider's public URL (deep links)
- Tests for all new modules (37 new tests)

### Modified files
- **Backend**: `sync.ts`, `deletion.ts`, `route.ts` use the resolver instead of importing Overseerr directly
- **Frontend**: `SyncStatus`, `AutoSyncSettings`, `DeletionConfirmDialog`, `MediaDetailModal` use `useProviderLabel()` context hook
- **Config**: `.env.example`, `docker-compose.yml`, `unraid/shelflife.xml`, `README.md` updated with all three providers

## Test plan

- [x] 451 tests pass (32 files, including 37 new tests for Seerr, Jellyseerr, and request-service)
- [x] `bun run build` succeeds
- [x] `bun run lint` — 0 errors
- [ ] With `SEERR_URL`/`SEERR_API_KEY` set: UI shows "Seerr", sync works
- [ ] With `OVERSEERR_URL`/`OVERSEERR_API_KEY` set: UI shows "Overseerr", sync works (backwards compatible)
- [ ] With `JELLYSEERR_URL`/`JELLYSEERR_API_KEY` set: UI shows "Jellyseerr", sync works
- [ ] With none set: app throws clear error at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)